### PR TITLE
Backscatter tracing and scatterer support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
 
 [deps]
+DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -14,6 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
+DiffEqCallbacks = "4.18.2"
 ForwardDiff = "1.3.3"
 LinearAlgebra = "1"
 NonlinearSolve = "4"
@@ -21,5 +23,5 @@ OrdinaryDiffEq = "7"
 OrdinaryDiffEqRosenbrock = "2.1.0"
 SciMLBase = "3.11.0"
 StaticArrays = "1.9.18"
-UnderwaterAcoustics = "0.4,0.5,0.6,0.7"
+UnderwaterAcoustics = "0.4,0.5,0.6,0.7,0.8"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AcousticRayTracers"
 uuid = "4fc4fbda-03ee-4929-b565-b3d9b12bdf79"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
 
 [deps]

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -1,12 +1,20 @@
 import LinearAlgebra: norm, dot
-import OrdinaryDiffEq: ODEProblem, VectorContinuousCallback, Tsit5, solve
+import OrdinaryDiffEq: ODEProblem, VectorContinuousCallback, CallbackSet, Tsit5, solve
 import OrdinaryDiffEqRosenbrock: Rosenbrock23
+import DiffEqCallbacks: StepsizeLimiter
 import NonlinearSolve: IntervalNonlinearProblem, NonlinearProblem
 import SciMLBase: successful_retcode, terminate!, remake
 import ForwardDiff: derivative
 import StaticArrays: SA, SVector
 
-Base.@kwdef struct RaySolver{T1,T2} <: AbstractRayPropagationModel
+# scatterers from the environment are wrapped into a ScattererSet at solver
+# construction; geometry queries go through the UnderwaterAcoustics scatterer API
+# (distance, boundary_projection, reflection_coef)
+struct ScattererSet{V}
+  items::V
+end
+
+Base.@kwdef struct RaySolver{T1,T2,T3} <: AbstractRayPropagationModel
   env::T1
   nbeams::Int = 0
   min_angle::Float64 = -deg2rad(80)
@@ -17,13 +25,18 @@ Base.@kwdef struct RaySolver{T1,T2} <: AbstractRayPropagationModel
   min_amplitude::Float64 = 1e-6
   solver::T2 = nothing
   solver_tol::Float64 = 1e-8
-  function RaySolver(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol)
+  backscatter::Bool = false
+  rmax::Float64 = 0.0
+  scatterers::T3 = nothing
+  function RaySolver(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol, backscatter, rmax, scatterers)
     nbeams < 0 && (nbeams = 0)
     -π/2 ≤ min_angle ≤ π/2 || error("min_angle should be between -π/2 and π/2")
     -π/2 ≤ max_angle ≤ π/2 || error("max_angle should be between -π/2 and π/2")
     min_angle < max_angle || error("max_angle should be more than min_angle")
+    rmax ≥ 0 || error("rmax should be non-negative")
     solver = something(solver, is_isovelocity(env) ? Tsit5() : Rosenbrock23())
-    new{typeof(env),typeof(solver)}(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol)
+    scatterers === nothing && (scatterers = _scatterer_set(env))
+    new{typeof(env),typeof(solver),typeof(scatterers)}(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol, backscatter, rmax, scatterers)
   end
 end
 
@@ -43,6 +56,14 @@ Supported keyword arguments:
 - `min_amplitude`: minimum ray amplitude to track (default: 1e-5)
 - `solver`: differential equation solver (default: nothing, auto)
 - `solver_tol`: solver tolerance (default: 1e-4)
+- `backscatter`: continue tracing rays that turn back toward the source (default: false)
+- `rmax`: right edge of modeling domain in m (default: 0, auto; 2× query range with backscatter)
+
+If the environment contains scatterers (`env.scatterers`), rays reflect off them
+using the scatterer's boundary condition. With `backscatter` enabled, rays are
+traced until they exit the modeling domain `r ∈ [0, rmax]` or become too weak
+(`min_amplitude`, including absorption); backscattered arrivals are reported with
+|arrival angle| > π/2.
 """
 RaySolver(env; kwargs...) = RaySolver(; env=env, kwargs...)
 
@@ -52,6 +73,7 @@ Base.show(io::IO, pm::RaySolver) = print(io, "RaySolver(⋯)")
 
 function UnderwaterAcoustics.arrivals(pm::RaySolver, tx::AbstractAcousticSource, rx::AbstractAcousticReceiver; paths=true, ztol=0.1)
   _check2d([tx], [rx])
+  pm.backscatter && return _arrivals_backscatter(pm, tx, rx; paths, ztol)
   p2 = location(rx)
   nbeams = pm.nbeams
   if nbeams == 0
@@ -142,6 +164,7 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
   mid_temp = (minimum(pm.env.temperature) + maximum(pm.env.temperature)) / 2
   c₀ = value(pm.env.soundspeed, location(tx))
   rmax = maximum(rxs.xrange) + 0.1
+  pm.backscatter && (rmax = pm.rmax > 0 ? pm.rmax : 2 * rmax)
   γ = absorption(f, 1, pm.env.salinity, mid_temp, h/2)  # nominal absorption per meter
   log_γ = log(γ)
   T = promote_type(env_type(pm.env), eltype(location(tx)), typeof(f), ComplexF64)
@@ -175,6 +198,7 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
         q = q1 + α * (q2 - q1)                          # spreading factor at cpa
         W = abs(q * δθ)                                 # beam width at cpa [COA (3.74)]
         cpa = pos1 + α * vec12                          # closest point of approach
+        cpa[1] > 0 || continue                          # no deposit at/behind the r=0 axis
         n = norm(cpa - rxpos)                           # normal distance from ray to rx
         n < 4W || continue                              # rx too far from ray segment
         A = C1 * sqrt(C2 / (cpa[1] * W))                # [COA (3.76)]
@@ -234,6 +258,43 @@ function _findall_rxgrid2d(rxs, r1, r2, z1, z2, tol)
   max(min(i,j),1):min(max(i,j),length(rxs.xrange)), max(min(k,l),1):min(max(k,l),length(rxs.zrange))
 end
 
+### scatterer support
+
+# wrap env.scatterers (UnderwaterAcoustics scatterer API) into a ScattererSet;
+# nothing if the environment has no scatterers
+function _scatterer_set(env)
+  s = hasproperty(env, :scatterers) ? env.scatterers : ()
+  length(s) == 0 ? nothing : ScattererSet(s)
+end
+
+# element type carried by scatterer geometry/boundary (may be a dual number)
+_scat_eltype(::Nothing) = Bool
+_scat_eltype(ss::ScattererSet) = mapreduce(_obj_eltype, promote_type, ss.items; init=Bool)
+_obj_eltype(x::Number) = typeof(real(x))
+_obj_eltype(x::Union{AbstractString,Function,Symbol}) = Bool
+_obj_eltype(x) = nfields(x) == 0 ? Bool : mapreduce(i -> _obj_eltype(getfield(x, i)), promote_type, 1:nfields(x); init=Bool)
+
+# minimum signed distance from (r, z) to any scatterer boundary (1-Lipschitz)
+_mindist(::Nothing, r, z) = nothing
+function _mindist(ss::ScattererSet, r, z)
+  pos = (x=r, y=zero(r), z=z)
+  minimum(s -> UnderwaterAcoustics.distance(s.shape, pos), ss.items)
+end
+
+# index of the scatterer nearest to (r, z)
+function _nearest(ss::ScattererSet, r, z)
+  pos = (x=r, y=zero(r), z=z)
+  jbest = 1
+  dbest = UnderwaterAcoustics.distance(ss.items[1].shape, pos)
+  for j ∈ 2:length(ss.items)
+    d = UnderwaterAcoustics.distance(ss.items[j].shape, pos)
+    d < dbest && (dbest = d; jbest = j)
+  end
+  jbest
+end
+
+### ray tracing core
+
 function _∂u((r, z, ξ, ζ, t, p, q), (c, ∂c, ∂²c), s)
   # implementation based on [COA (3.161-164, 3.58-63)]
   # assumes range-independent soundspeed
@@ -243,11 +304,41 @@ function _∂u((r, z, ξ, ζ, t, p, q), (c, ∂c, ∂²c), s)
   SA[cᵥ * ξ, cᵥ * ζ, 0, -∂c(z) / cᵥ², 1 / cᵥ, -c̄ * q, cᵥ * p]
 end
 
-function _check_ray!(out, u, s, integrator, a, b, rmax)
+# events: 1 = surface, 2 = bottom, 3 = max range, 4 = ray turned back (legacy) or
+# exited past the source (backscatter), 5 = scatterer hit, 6 = receiver range
+# crossing (recorded, not terminal). Inert slots hold one(u[1]) so they never fire
+# and preserve the element type (dual numbers).
+function _check_ray!(out, u, s, integrator, a, b, rmax, backscatter, ss, δ, guard, r_rx)
   out[1] = value(a, (u[1], 0.0, 0.0)) - u[2]    # surface reflection
   out[2] = u[2] + value(b, (u[1], 0.0, 0.0))    # bottom reflection
   out[3] = rmax - u[1]                          # maximum range
-  out[4] = u[3]                                 # ray turned back
+  out[4] = backscatter ? u[1] + δ : u[3]        # exit past source / ray turned back
+  out[5] = ss === nothing || s < guard ? one(u[1]) : _mindist(ss, u[1], u[2]) - δ
+  out[6] = isnan(r_rx) ? one(u[1]) : u[1] - r_rx
+end
+
+# handle a fired ray event: event 6 (receiver-range crossing) is recorded and
+# integration continues; any other event terminates the segment and its index is
+# reported via evref. Depending on the DiffEqBase version, ndx is either the
+# event index or a vector of simultaneous event flags (0 = not fired, ±1 = fired)
+function _ray_event!(i, ndx::Integer, crossbuf, evref)
+  if ndx == 6
+    push!(crossbuf, (i.t, i.u))
+  else
+    evref[] = Int(ndx)
+    terminate!(i)
+  end
+end
+
+function _ray_event!(i, ndx::AbstractVector, crossbuf, evref)
+  length(ndx) ≥ 6 && ndx[6] != 0 && push!(crossbuf, (i.t, i.u))
+  for k ∈ 1:min(length(ndx), 5)
+    if ndx[k] != 0
+      evref[] = k
+      terminate!(i)
+      break
+    end
+  end
 end
 
 # prepare to trace a ray segment
@@ -259,27 +350,45 @@ function _prepare_trace(T, pm)
 end
 
 # trace a ray starting at (r0, z0) with angle θ until it hits the surface,
-# bottom, or reaches rmax. T is the type to use for computations, and p0, q0
-# are the initial spreading parameters (default to 1/c₀ and 0, respectively).
-# ds controls the spacing of points along the ray (0 = only events).
+# bottom, a scatterer, or reaches the domain limits. T is the type to use for
+# computations, and p0, q0 are the initial spreading parameters (default to 1/c₀
+# and 0, respectively). ds controls the spacing of points along the ray
+# (0 = only events). guard suppresses scatterer detection for a short arc length
+# after a scatterer bounce; crossbuf collects receiver-range crossings (event 6)
+# and evref reports which terminal event fired (0 = none).
 # Returns a 2-tuple of vectors containing distances along the ray, and
 # (r, z, ξ, ζ, t, p, q) values at each point.
-function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0)
+function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossbuf, evref, r_rx, hmax)
   a = pm.env.altimetry
   b = pm.env.bathymetry
+  ss = pm.scatterers
+  bs = pm.backscatter
   cᵥ = value(pm.env.soundspeed, z0)
   u0 = SA[convert(T, r0), z0, cos(θ)/cᵥ, sin(θ)/cᵥ, zero(T), p0, q0]
-  tspan = (zero(T), one(T) * pm.rugosity * (rmax-r0)/cos(θ))
+  # legacy tspan formula assumes forward-going rays (|θ| < π/2); with backscatter
+  # or scatterers, use a geometry-based bound instead (segments end at events)
+  span = bs || ss !== nothing ? one(T) * pm.rugosity * (rmax + 4hmax) : one(T) * pm.rugosity * (rmax-r0)/cos(θ)
+  tspan = (zero(T), span)
   prob = remake(prob; u0, tspan)
+  δ = one(T) * pm.atol
   cb = VectorContinuousCallback(
-    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax),
-    (i, ndx) -> terminate!(i), 4;
+    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, bs, ss, δ, guard, r_rx),
+    (i, ndx) -> _ray_event!(i, ndx, crossbuf, evref), 6;
     rootfind = true
   )
-  if ds ≤ 0
-    soln = solve(prob, pm.solver; abstol=pm.solver_tol, save_everystep=false, callback=cb)
+  if ss === nothing
+    cbs = cb
   else
-    soln = solve(prob, pm.solver; abstol=pm.solver_tol, saveat=ds, callback=cb)
+    # anti-tunneling: since the independent variable is arc length and distance
+    # is 1-Lipschitz, dt ≤ 0.9 × distance guarantees a step cannot jump over a
+    # scatterer without the event function bracketing the surface (sphere tracing)
+    limiter = StepsizeLimiter((u, pp, s) -> max(_mindist(ss, u[1], u[2]), δ); safety_factor=9//10, cached_dtcache=zero(T))
+    cbs = CallbackSet(limiter, cb)
+  end
+  if ds ≤ 0
+    soln = solve(prob, pm.solver; abstol=pm.solver_tol, save_everystep=false, callback=cbs)
+  else
+    soln = solve(prob, pm.solver; abstol=pm.solver_tol, saveat=ds, callback=cbs)
   end
   (soln.t, soln.u)
 end
@@ -287,28 +396,40 @@ end
 # trace a ray starting at tx1 with angle θ until it reaches rmax. ds controls the
 # spacing of points along the ray. If paths=true, also returns the ray path as a
 # vector of (x, y, z) points. If aux=true, also returns auxiliary info as a vector
-# of (s, q, t, A) tuples at each point.
-function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; paths=true, aux=false)
+# of (s, q, t, A) tuples at each point. If r_rx is given (not NaN), receiver-range
+# crossings are recorded and returned as the third element of the result.
+function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; paths=true, aux=false, r_rx=NaN)
   θ₀ = θ
   f = frequency(tx1)
   mid_temp = (minimum(pm.env.temperature) + maximum(pm.env.temperature)) / 2
-  zmin = -maximum(pm.env.bathymetry)
+  hmax = maximum(pm.env.bathymetry)
+  zmin = -hmax
   ϵ = one(zmin) * pm.solver_tol
   p = location(tx1)
   c₀ = value(pm.env.soundspeed, p)
-  T = promote_type(env_type(pm.env), eltype(p), typeof(f), typeof(θ), typeof(rmax))
+  T = promote_type(env_type(pm.env), eltype(p), typeof(f), typeof(θ), typeof(rmax), _scat_eltype(pm.scatterers))
   raypath = Array{@NamedTuple{x::T,y::T,z::T}}(undef, 0)
   aux_info = Array{Tuple{T,T,T,Complex{T}}}(undef, 0)
+  crossings = Array{@NamedTuple{z::T,t::T,θ::T,q::T,A::Complex{T},dir::Int,D::T,ns::Int,nb::Int,nsc::Int,pathlen::Int}}(undef, 0)
+  crossbuf = Array{Tuple{T,SVector{7,T}}}(undef, 0)
+  evref = Ref(0)
+  rxr = convert(T, r_rx)
   prob = _prepare_trace(T, pm)
   A = one(Complex{T})   # phasor
   s = 0                 # surface bounces
   b = 0                 # bottom bounces
+  sc = 0                # scatterer bounces
   t = zero(T)           # time along ray
   D = zero(T)           # distance along ray
   q = zero(T)           # spreading factor
   qp = one(T) / c₀      # spreading rate
+  guard = zero(T)       # arc length over which scatterer detection is suppressed
   while true
-    svec, u = _trace_segment(T, prob, pm, p[1], p[3], θ, rmax, ds, qp, q)
+    empty!(crossbuf)
+    evref[] = 0
+    npath0 = length(raypath)
+    svec, u = _trace_segment(T, prob, pm, p[1], p[3], θ, rmax, ds, qp, q, guard, crossbuf, evref, rxr, hmax)
+    guard = zero(T)
     r, z, ξ, ζ, dt, qp, q = u[end]
     dD = svec[end]
     θ = atan(ζ, ξ)
@@ -324,22 +445,54 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
         push!(aux_info, (D + svec[i], u[i][7], t + u[i][5], A))
       end
     end
+    for (sx, ux) ∈ crossbuf     # receiver-range crossings within this segment
+      kx = 0                    # KMAH count up to the crossing point
+      npts = 0
+      oqx = u[1][7]
+      for i ∈ eachindex(u)
+        svec[i] > sx && break
+        npts += 1
+        sign(oqx) * sign(u[i][7]) == -1 && (kx += 1)
+        u[i][7] != 0.0 && (oqx = u[i][7])
+      end
+      push!(crossings, (; z=ux[2], t=t+ux[5], θ=atan(ux[4], ux[3]), q=ux[7],
+        A=A*cis(-π/2*kx), dir=Int(sign(ux[3])), D=D+sx, ns=s, nb=b, nsc=sc,
+        pathlen=paths ? npath0+npts : 0))
+    end
     t += dt
     D += dD
     A *= cis(-π/2 * kmah)                 # [COA §3.4.1 (KMAH correction)]
     zmin = -value(pm.env.bathymetry, (r, 0.0, 0.0))
     zmax = value(pm.env.altimetry, (r, 0.0, 0.0))
     p = (r, 0.0, clamp(z, zmin+ϵ, zmax-ϵ))
+    ev = evref[]
     if r ≥ rmax - 1e-3
       break
-    elseif isapprox(z, zmax; atol=1e-3)   # hit the surface
+    elseif ev == 5                        # hit a scatterer
+      sc += 1
+      sca = pm.scatterers.items[_nearest(pm.scatterers, r, z)]
+      hit = UnderwaterAcoustics.boundary_projection(sca.shape, (x=r, y=zero(r), z=z))
+      n̂ = SA[hit.normal.x, hit.normal.z]
+      t̂ = SA[cos(θ), sin(θ)]
+      dp = dot(t̂, n̂)
+      t̂′ = t̂ - 2dp * n̂                    # specular reflection off local tangent plane
+      θ = atan(t̂′[2], t̂′[1])
+      sinθg = clamp(abs(dp), zero(dp), one(dp))
+      ρ = value(pm.env.density, (r, 0.0, z))
+      c = value(pm.env.soundspeed, (r, 0.0, z))
+      A *= reflection_coef(sca.boundary, f, asin(sinθg), ρ, c)
+      # dynamic ray tracing correction for reflection off a curved boundary
+      # [COA (3.123-3.128)]; skipped near grazing where the correction diverges
+      sinθg > 1e-3 && (qp += q * 2 * hit.curvature / (c * sinθg))
+      guard = 2 * one(T) * pm.atol
+    elseif ev == 1 && isapprox(z, zmax; atol=1e-3)   # hit the surface
       s += 1
       ρ = value(pm.env.density, (r, 0.0, 0.0))
       c = value(pm.env.soundspeed, (r, 0.0, 0.0))
       A *= reflection_coef(pm.env.surface, f, π/2 - θ, ρ, c)
       α = atan(derivative(x -> value(pm.env.altimetry, (x, 0.0, 0.0)), r))
       θ = -θ + 2α
-    elseif isapprox(z, zmin; atol=1e-3)   # hit the bottom
+    elseif ev == 2 && isapprox(z, zmin; atol=1e-3)   # hit the bottom
       b += 1
       ρ = value(pm.env.density, (r, 0.0, z))
       c = value(pm.env.soundspeed, (r, 0.0, z))
@@ -349,13 +502,134 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
     else
       break
     end
-    abs(θ) ≥ π/2 && break
-    abs(A)/abs(q) < pm.min_amplitude && break
+    if pm.backscatter
+      abs(A) * absorption(f, D, pm.env.salinity, mid_temp, hmax/2) / abs(q) < pm.min_amplitude && break
+    else
+      abs(θ) ≥ π/2 && break
+      abs(A)/abs(q) < pm.min_amplitude && break
+    end
   end
   cₛ = value(pm.env.soundspeed, p)
   A *= √abs(cₛ * cos(θ₀) / (p[1] * c₀ * q))                   # [COA (3.65)]
   A *= absorption(f, D, pm.env.salinity, mid_temp, -zmin/2)   # nominal absorption
-  RayArrival(t, A, s, b, θ₀, -θ, raypath), aux_info
+  RayArrival(t, A, s, b, θ₀, -θ, raypath), aux_info, crossings
 end
 
 _Δz(ϕ, (pm, tx1, rmax, z)) = _trace(pm, tx1, ϕ, rmax)[1].path[end].z - z
+
+### backscatter eigenray search
+
+# crossings are grouped by "signature" — direction of travel + bounce history —
+# so that the depth error Δz(θ) restricted to one signature is continuous in θ
+# and the standard bracketing/root-finding machinery applies
+_sigbase(cr) = (cr.dir, cr.ns, cr.nb, cr.nsc)
+
+# signature of each crossing: (dir, ns, nb, nsc, ordinal within that history)
+function _sigs(crossings)
+  counts = Dict{NTuple{4,Int},Int}()
+  map(crossings) do cr
+    base = _sigbase(cr)
+    k = get(counts, base, 0) + 1
+    counts[base] = k
+    (base..., k)
+  end
+end
+
+# index of the crossing matching a signature, or nothing
+function _findsig(crossings, sig)
+  base = sig[1:4]
+  k = 0
+  for i ∈ eachindex(crossings)
+    if _sigbase(crossings[i]) == base
+      k += 1
+      k == sig[5] && return i
+    end
+  end
+  nothing
+end
+
+# depth error at the receiver range for the crossing matching sig
+function _Δz_sig(ϕ, (pm, tx1, rdom, r_rx, z, sig))
+  crs = _trace(pm, tx1, ϕ, rdom; paths=false, r_rx)[3]
+  i = _findsig(crs, sig)
+  i === nothing ? convert(promote_type(typeof(ϕ), typeof(z)), NaN) : crs[i].z - z
+end
+
+# trace a ray and construct a RayArrival from the crossing matching sig,
+# applying the COA (3.65) amplitude formula and nominal absorption at the
+# crossing point; nothing if the signature is absent for this launch angle
+function _crossing_arrival(pm, tx1, θ, rdom, r_rx, sig, ds; paths=true)
+  f = frequency(tx1)
+  mid_temp = (minimum(pm.env.temperature) + maximum(pm.env.temperature)) / 2
+  hmax = maximum(pm.env.bathymetry)
+  c₀ = value(pm.env.soundspeed, location(tx1))
+  arr, _, crs = _trace(pm, tx1, θ, rdom, ds; paths, r_rx)
+  i = _findsig(crs, sig)
+  i === nothing && return nothing
+  cr = crs[i]
+  cₛ = value(pm.env.soundspeed, (r_rx, 0.0, cr.z))
+  A = cr.A * √abs(cₛ * cos(θ) / (r_rx * c₀ * cr.q))           # [COA (3.65)]
+  A *= absorption(f, cr.D, pm.env.salinity, mid_temp, hmax/2) # nominal absorption
+  path = paths ? [arr.path[1:cr.pathlen]; xyz(oftype(cr.z, r_rx), zero(cr.z), cr.z)] : arr.path[1:0]
+  RayArrival(cr.t, A, cr.ns, cr.nb, θ, -cr.θ, path)
+end
+
+function _arrivals_backscatter(pm::RaySolver, tx::AbstractAcousticSource, rx::AbstractAcousticReceiver; paths=true, ztol=0.1)
+  p2 = location(rx)
+  r_rx = p2.x
+  hmax = maximum(pm.env.bathymetry)
+  rdom = pm.rmax > 0 ? pm.rmax : max(2 * r_rx, r_rx + 2 * hmax)
+  nbeams = pm.nbeams
+  if nbeams == 0
+    R = max(abs(r_rx - location(tx).x), hmax)
+    nbeams = ceil(Int, 16 * (pm.max_angle - pm.min_angle) / atan(hmax, R))
+  end
+  ds = pm.ds ≤ 0 ? minimum(pm.env.bathymetry) / 10 : pm.ds
+  θ = range(pm.min_angle, pm.max_angle; length=nbeams)
+  T1 = promote_type(env_type(pm.env), eltype(location(tx)), typeof(p2.x), typeof(p2.z))
+  crs_all = tmap(θ1 -> _trace(pm, tx, T1(θ1), T1(rdom); paths=false, r_rx)[3], θ)
+  allsigs = Set{NTuple{5,Int}}()
+  foreach(crs -> union!(allsigs, _sigs(crs)), crs_all)
+  T2 = typeof(RayArrival(zero(T1), zero(Complex{T1}), 0, 0, zero(T1), zero(T1),
+    Array{@NamedTuple{x::T1,y::T1,z::T1}}(undef, 0)))
+  erays = Channel{T2}(Inf)
+  for sig ∈ allsigs
+    err = map(crs_all) do crs
+      i = _findsig(crs, sig)
+      i === nothing ? T1(NaN) : T1(crs[i].z - p2.z)
+    end
+    prob1 = IntervalNonlinearProblem{false}(_Δz_sig, T1.((θ[1], θ[1])), (pm, tx, T1(rdom), T1(r_rx), T1(p2.z), sig))
+    prob2 = NonlinearProblem{false}(_Δz_sig, T1(θ[1]), (pm, tx, T1(rdom), T1(r_rx), T1(p2.z), sig))
+    Threads.@threads for i ∈ 1:length(θ)
+      if isapprox(err[i], 0; atol=pm.atol)
+        # crossing already at receiver
+        v = _crossing_arrival(pm, tx, T1(θ[i]), T1(rdom), T1(r_rx), sig, ds; paths)
+        v === nothing || put!(erays, v)
+      elseif i > 1 && !isnan(err[i-1]) && !isnan(err[i]) && sign(err[i-1]) * sign(err[i]) < 0
+        # crossings bracket the receiver, so find a root in between...
+        soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=pm.atol)
+        if successful_retcode(soln.retcode) && abs(soln.resid) < ztol
+          v = _crossing_arrival(pm, tx, soln.u, T1(rdom), T1(r_rx), sig, ds; paths)
+          v === nothing || put!(erays, v)
+        end
+      elseif i > 2 && _isnearzero(err[i-2], err[i-1], err[i])
+        # at a turning point, so potentially two roots between i-2 and i, try and find both...
+        lims = _ordered(θ[i-2], θ[i])
+        soln = solve(remake(prob2; u0=T1(θ[i-1])); abstol=pm.atol)
+        if successful_retcode(soln.retcode) && abs(soln.resid) < ztol && lims[1] < soln.u < lims[2]
+          θ₁ = soln.u
+          v = _crossing_arrival(pm, tx, θ₁, T1(rdom), T1(r_rx), sig, ds; paths)
+          v === nothing || put!(erays, v)
+          soln = solve(remake(prob2; u0=T1(θ[i-1] < θ₁ ? lims[2] : lims[1])); abstol=pm.atol)
+          if successful_retcode(soln.retcode) && abs(soln.resid) < ztol &&
+             (θ[i-1] < θ₁ ? θ₁ < soln.u < lims[2] : lims[1] < soln.u < θ₁)
+            v = _crossing_arrival(pm, tx, soln.u, T1(rdom), T1(r_rx), sig, ds; paths)
+            v === nothing || put!(erays, v)
+          end
+        end
+      end
+    end
+  end
+  close(erays)
+  sort(collect(erays); by=Base.Fix2(getfield, :t))
+end

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -26,17 +26,19 @@ Base.@kwdef struct RaySolver{T1,T2,T3} <: AbstractRayPropagationModel
   solver::T2 = nothing
   solver_tol::Float64 = 1e-8
   backscatter::Bool = false
+  rmin::Float64 = 0.0
   rmax::Float64 = 0.0
   scatterers::T3 = nothing
-  function RaySolver(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol, backscatter, rmax, scatterers)
+  function RaySolver(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol, backscatter, rmin, rmax, scatterers)
     nbeams < 0 && (nbeams = 0)
     -π/2 ≤ min_angle ≤ π/2 || error("min_angle should be between -π/2 and π/2")
     -π/2 ≤ max_angle ≤ π/2 || error("max_angle should be between -π/2 and π/2")
     min_angle < max_angle || error("max_angle should be more than min_angle")
+    rmin ≤ 0 || error("rmin should be non-positive")
     rmax ≥ 0 || error("rmax should be non-negative")
     solver = something(solver, is_isovelocity(env) ? Tsit5() : Rosenbrock23())
     scatterers === nothing && (scatterers = _scatterer_set(env))
-    new{typeof(env),typeof(solver),typeof(scatterers)}(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol, backscatter, rmax, scatterers)
+    new{typeof(env),typeof(solver),typeof(scatterers)}(env, nbeams, min_angle, max_angle, ds, atol, rugosity, min_amplitude, solver, solver_tol, backscatter, rmin, rmax, scatterers)
   end
 end
 
@@ -57,13 +59,18 @@ Supported keyword arguments:
 - `solver`: differential equation solver (default: nothing, auto)
 - `solver_tol`: solver tolerance (default: 1e-4)
 - `backscatter`: continue tracing rays that turn back toward the source (default: false)
-- `rmax`: right edge of modeling domain in m (default: 0, auto; 2× query range with backscatter)
+- `rmin`: left edge of modeling domain in m, ≤ 0 (default: 0; only meaningful with backscatter)
+- `rmax`: right edge of modeling domain in m (default: 0, auto = query range)
 
 If the environment contains scatterers (`env.scatterers`), rays reflect off them
 using the scatterer's boundary condition. With `backscatter` enabled, rays are
-traced until they exit the modeling domain `r ∈ [0, rmax]` or become too weak
+traced until they exit the modeling domain `r ∈ [rmin, rmax]` or become too weak
 (`min_amplitude`, including absorption); backscattered arrivals are reported with
-|arrival angle| > π/2.
+|arrival angle| > π/2. Features outside the modeling domain are invisible; set
+`rmax` beyond the query range to capture echoes from behind the receivers.
+If `rmin < 0`, a second fan of rays with the same elevation angles is launched
+in the -x direction, so that features to the left of the transmitter can also
+produce echoes (such arrivals have |launch angle| > π/2).
 """
 RaySolver(env; kwargs...) = RaySolver(; env=env, kwargs...)
 
@@ -164,13 +171,14 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
   mid_temp = (minimum(pm.env.temperature) + maximum(pm.env.temperature)) / 2
   c₀ = value(pm.env.soundspeed, location(tx))
   rmax = maximum(rxs.xrange) + 0.1
-  pm.backscatter && (rmax = pm.rmax > 0 ? pm.rmax : 2 * rmax)
+  pm.backscatter && pm.rmax > 0 && (rmax = pm.rmax)
   γ = absorption(f, 1, pm.env.salinity, mid_temp, h/2)  # nominal absorption per meter
   log_γ = log(γ)
   T = promote_type(env_type(pm.env), eltype(location(tx)), typeof(f), ComplexF64)
   afld = zeros(T, size(rxs,1), size(rxs,2))
   afld_lock = [ReentrantLock() for _ ∈ 1:size(rxs,1)]
-  Threads.@threads for θ₀ ∈ θ
+  θs = pm.backscatter && pm.rmin < 0 ? vcat(collect(θ), rem2pi.(π .- θ, RoundNearest)) : collect(θ)
+  Threads.@threads for θ₀ ∈ θs
     ray, aux_info = _trace(pm, tx, θ₀, rmax, ds; aux=true)
     for i ∈ 1:length(ray.path)-1
       pos1 = SA[ray.path[i].x, ray.path[i].z]           # start of ray segment
@@ -184,7 +192,7 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
       end
       C1 = A1 * γₛ / √π                                 # √π scaling for Gaussian beams
       mode === :incoherent && (C1 *= π/2)               # scaling for incoherent summation
-      C2 = δθ * cos(θ₀) * cₛ / c₀
+      C2 = δθ * abs(cos(θ₀)) * cₛ / c₀
       xi, zi = _findall_rxgrid2d(rxs,                   # subset of rx in neighborhood
         ray.path[i].x, ray.path[i+1].x,                 #  of ray segment
         ray.path[i].z, ray.path[i+1].z,
@@ -308,11 +316,11 @@ end
 # exited past the source (backscatter), 5 = scatterer hit, 6 = receiver range
 # crossing (recorded, not terminal). Inert slots hold one(u[1]) so they never fire
 # and preserve the element type (dual numbers).
-function _check_ray!(out, u, s, integrator, a, b, rmax, backscatter, ss, δ, guard, r_rx)
+function _check_ray!(out, u, s, integrator, a, b, rmax, rmin, backscatter, ss, δ, guard, r_rx)
   out[1] = value(a, (u[1], 0.0, 0.0)) - u[2]    # surface reflection
   out[2] = u[2] + value(b, (u[1], 0.0, 0.0))    # bottom reflection
   out[3] = rmax - u[1]                          # maximum range
-  out[4] = backscatter ? u[1] + δ : u[3]        # exit past source / ray turned back
+  out[4] = backscatter ? u[1] - rmin + δ : u[3] # exit domain left / ray turned back
   out[5] = ss === nothing || s < guard ? one(u[1]) : _mindist(ss, u[1], u[2]) - δ
   out[6] = isnan(r_rx) ? one(u[1]) : u[1] - r_rx
 end
@@ -367,12 +375,13 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
   u0 = SA[convert(T, r0), z0, cos(θ)/cᵥ, sin(θ)/cᵥ, zero(T), p0, q0]
   # legacy tspan formula assumes forward-going rays (|θ| < π/2); with backscatter
   # or scatterers, use a geometry-based bound instead (segments end at events)
-  span = bs || ss !== nothing ? one(T) * pm.rugosity * (rmax + 4hmax) : one(T) * pm.rugosity * (rmax-r0)/cos(θ)
+  rmin = one(T) * pm.rmin
+  span = bs || ss !== nothing ? one(T) * pm.rugosity * (rmax - rmin + 4hmax) : one(T) * pm.rugosity * (rmax-r0)/cos(θ)
   tspan = (zero(T), span)
   prob = remake(prob; u0, tspan)
   δ = one(T) * pm.atol
   cb = VectorContinuousCallback(
-    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, bs, ss, δ, guard, r_rx),
+    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, rmin, bs, ss, δ, guard, r_rx),
     (i, ndx) -> _ray_event!(i, ndx, crossbuf, evref), 6;
     rootfind = true
   )
@@ -578,7 +587,7 @@ function _arrivals_backscatter(pm::RaySolver, tx::AbstractAcousticSource, rx::Ab
   p2 = location(rx)
   r_rx = p2.x
   hmax = maximum(pm.env.bathymetry)
-  rdom = pm.rmax > 0 ? pm.rmax : max(2 * r_rx, r_rx + 2 * hmax)
+  rdom = pm.rmax > 0 ? pm.rmax : r_rx + 0.1
   nbeams = pm.nbeams
   if nbeams == 0
     R = max(abs(r_rx - location(tx).x), hmax)
@@ -587,29 +596,42 @@ function _arrivals_backscatter(pm::RaySolver, tx::AbstractAcousticSource, rx::Ab
   ds = pm.ds ≤ 0 ? minimum(pm.env.bathymetry) / 10 : pm.ds
   θ = range(pm.min_angle, pm.max_angle; length=nbeams)
   T1 = promote_type(env_type(pm.env), eltype(location(tx)), typeof(p2.x), typeof(p2.z))
-  crs_all = tmap(θ1 -> _trace(pm, tx, T1(θ1), T1(rdom); paths=false, r_rx)[3], θ)
-  allsigs = Set{NTuple{5,Int}}()
-  foreach(crs -> union!(allsigs, _sigs(crs)), crs_all)
   T2 = typeof(RayArrival(zero(T1), zero(Complex{T1}), 0, 0, zero(T1), zero(T1),
     Array{@NamedTuple{x::T1,y::T1,z::T1}}(undef, 0)))
   erays = Channel{T2}(Inf)
+  _fan_search!(erays, pm, tx, collect(T1, θ), T1(rdom), T1(r_rx), T1(p2.z), ds, ztol, paths)
+  if pm.rmin < 0    # also insonify the left halfspace with a mirrored fan
+    _fan_search!(erays, pm, tx, collect(T1, rem2pi.(π .- θ, RoundNearest)), T1(rdom), T1(r_rx), T1(p2.z), ds, ztol, paths)
+  end
+  close(erays)
+  sort(collect(erays); by=Base.Fix2(getfield, :t))
+end
+
+# eigenray search over one launch-angle fan: find receiver-range crossings for
+# each launch angle, group by signature, and root-find on the per-signature
+# depth error using the same 3-way logic as the forward eigenray search
+function _fan_search!(erays, pm::RaySolver, tx::AbstractAcousticSource, θ, rdom, r_rx, zrx, ds, ztol, paths)
+  T1 = eltype(θ)
+  crs_all = tmap(θ1 -> _trace(pm, tx, θ1, rdom; paths=false, r_rx)[3], θ)
+  allsigs = Set{NTuple{5,Int}}()
+  foreach(crs -> union!(allsigs, _sigs(crs)), crs_all)
   for sig ∈ allsigs
     err = map(crs_all) do crs
       i = _findsig(crs, sig)
-      i === nothing ? T1(NaN) : T1(crs[i].z - p2.z)
+      i === nothing ? T1(NaN) : T1(crs[i].z - zrx)
     end
-    prob1 = IntervalNonlinearProblem{false}(_Δz_sig, T1.((θ[1], θ[1])), (pm, tx, T1(rdom), T1(r_rx), T1(p2.z), sig))
-    prob2 = NonlinearProblem{false}(_Δz_sig, T1(θ[1]), (pm, tx, T1(rdom), T1(r_rx), T1(p2.z), sig))
+    prob1 = IntervalNonlinearProblem{false}(_Δz_sig, T1.((θ[1], θ[1])), (pm, tx, rdom, r_rx, zrx, sig))
+    prob2 = NonlinearProblem{false}(_Δz_sig, T1(θ[1]), (pm, tx, rdom, r_rx, zrx, sig))
     Threads.@threads for i ∈ 1:length(θ)
       if isapprox(err[i], 0; atol=pm.atol)
         # crossing already at receiver
-        v = _crossing_arrival(pm, tx, T1(θ[i]), T1(rdom), T1(r_rx), sig, ds; paths)
+        v = _crossing_arrival(pm, tx, θ[i], rdom, r_rx, sig, ds; paths)
         v === nothing || put!(erays, v)
       elseif i > 1 && !isnan(err[i-1]) && !isnan(err[i]) && sign(err[i-1]) * sign(err[i]) < 0
         # crossings bracket the receiver, so find a root in between...
         soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=pm.atol)
         if successful_retcode(soln.retcode) && abs(soln.resid) < ztol
-          v = _crossing_arrival(pm, tx, soln.u, T1(rdom), T1(r_rx), sig, ds; paths)
+          v = _crossing_arrival(pm, tx, soln.u, rdom, r_rx, sig, ds; paths)
           v === nothing || put!(erays, v)
         end
       elseif i > 2 && _isnearzero(err[i-2], err[i-1], err[i])
@@ -618,18 +640,17 @@ function _arrivals_backscatter(pm::RaySolver, tx::AbstractAcousticSource, rx::Ab
         soln = solve(remake(prob2; u0=T1(θ[i-1])); abstol=pm.atol)
         if successful_retcode(soln.retcode) && abs(soln.resid) < ztol && lims[1] < soln.u < lims[2]
           θ₁ = soln.u
-          v = _crossing_arrival(pm, tx, θ₁, T1(rdom), T1(r_rx), sig, ds; paths)
+          v = _crossing_arrival(pm, tx, θ₁, rdom, r_rx, sig, ds; paths)
           v === nothing || put!(erays, v)
           soln = solve(remake(prob2; u0=T1(θ[i-1] < θ₁ ? lims[2] : lims[1])); abstol=pm.atol)
           if successful_retcode(soln.retcode) && abs(soln.resid) < ztol &&
              (θ[i-1] < θ₁ ? θ₁ < soln.u < lims[2] : lims[1] < soln.u < θ₁)
-            v = _crossing_arrival(pm, tx, soln.u, T1(rdom), T1(r_rx), sig, ds; paths)
+            v = _crossing_arrival(pm, tx, soln.u, rdom, r_rx, sig, ds; paths)
             v === nothing || put!(erays, v)
           end
         end
       end
     end
   end
-  close(erays)
-  sort(collect(erays); by=Base.Fix2(getfield, :t))
+  nothing
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,8 +7,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
-
-# TEMPORARY: exercise the scatterer API in CI until UnderwaterAcoustics 0.8 is
-# registered; remove this [sources] section after registration
-[sources]
-UnderwaterAcoustics = { url = "https://github.com/org-arl/UnderwaterAcoustics.jl", rev = "master" }

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,3 +7,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
+
+# TEMPORARY: exercise the scatterer API in CI until UnderwaterAcoustics 0.8 is
+# registered; remove this [sources] section after registration
+[sources]
+UnderwaterAcoustics = { url = "https://github.com/org-arl/UnderwaterAcoustics.jl", rev = "master" }

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -151,6 +151,20 @@ end
   @test abs(bck[1].ϕ) < abs(fwd[1].ϕ)               # weaker than the direct arrival
   # all eigenray paths (forward and backscattered) must end at the receiver
   @test all(a -> abs(a.path[end].x - 40) < 0.5 && abs(a.path[end].z + 10) < 0.5, arr2)
+  # with default rmax (= query range), the wall at 85-100 m is outside the
+  # domain and produces no echoes
+  arr3 = arrivals(RaySolver(env2; backscatter=true), tx2, rx2)
+  @test count(a -> abs(a.θᵣ) > π/2, arr3) == 0
+  # wall to the LEFT of the source: echoes require rmin < 0 (mirrored fan)
+  bathy4 = SampledField([2, 20, 20]; x=[-100, -80, 200])
+  env4 = UnderwaterEnvironment(bathymetry=bathy4, seabed=RigidBoundary, soundspeed=1500.0)
+  tx4 = AcousticSource(0.0, -10.0, 1000.0)
+  rx4 = AcousticReceiver(50.0, -10.0)
+  arr4a = arrivals(RaySolver(env4; backscatter=true), tx4, rx4)
+  arr4b = arrivals(RaySolver(env4; backscatter=true, rmin=-100.0, rmax=100.0), tx4, rx4)
+  @test count(a -> abs(a.θₛ) > π/2, arr4a) == 0
+  @test count(a -> abs(a.θₛ) > π/2, arr4b) > 0
+  @test all(a -> abs(a.path[end].x - 50) < 0.5 && abs(a.path[end].z + 10) < 0.5, arr4b)
 end
 
 @testitem "∂raysolver-backscatter" begin
@@ -179,14 +193,14 @@ end
       scatterers = (Scatterer(Ellipse(50.0, -20.0, 2.0, 2.0), RigidBoundary),))
     tx = AcousticSource(0.0, -20.0, 5000.0)
     rx = AcousticReceiver(10.0, -20.0)
-    pm = RaySolver(env; backscatter=true)
+    pm = RaySolver(env; backscatter=true, rmax=60.0)
     arr = arrivals(pm, tx, rx)
     bsc = filter(a -> abs(a.θᵣ) > π/2, arr)
     @test any(a -> isapprox(a.t, 86/1500; atol=1e-3), bsc)
     # pressure-release scatterer: backscattered arrival flips phase by π
     env2 = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
       scatterers = (Scatterer(Ellipse(50.0, -20.0, 2.0, 2.0), PressureReleaseBoundary),))
-    arr2 = arrivals(RaySolver(env2; backscatter=true), tx, rx)
+    arr2 = arrivals(RaySolver(env2; backscatter=true, rmax=60.0), tx, rx)
     bsc2 = filter(a -> abs(a.θᵣ) > π/2, arr2)
     a1 = bsc[argmin([abs(a.t - 86/1500) for a ∈ bsc])]
     a2 = bsc2[argmin([abs(a.t - 86/1500) for a ∈ bsc2])]
@@ -194,13 +208,13 @@ end
     # anti-tunneling: a small scatterer (0.5 m radius) must still be detected
     env3 = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
       scatterers = (Scatterer(Ellipse(50.0, -20.0, 0.5, 0.5), RigidBoundary),))
-    arr3 = arrivals(RaySolver(env3; backscatter=true), tx, rx)
+    arr3 = arrivals(RaySolver(env3; backscatter=true, rmax=60.0), tx, rx)
     @test any(a -> abs(a.θᵣ) > π/2 && isapprox(a.t, (49.5 + 39.5)/1500; atol=1e-3), arr3)
     # shadow: coherent field behind the scatterer drops relative to no-scatterer case
     env4 = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0)
     rx2 = AcousticReceiver(60.0, -20.0)
     tl_free = transmission_loss(RaySolver(env4), tx, rx2)
-    tl_shad = transmission_loss(RaySolver(env; backscatter=true), tx, rx2)
+    tl_shad = transmission_loss(RaySolver(env; backscatter=true, rmax=60.0), tx, rx2)
     @test tl_shad > tl_free
     # AD through scatterer geometry
     using DifferentiationInterface
@@ -209,7 +223,7 @@ end
     function ℳ((sx, sz, sa))
       envg = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
         scatterers = (Scatterer(Ellipse(sx, sz, sa, sa), RigidBoundary),))
-      pmg = RaySolver(envg; backscatter=true)
+      pmg = RaySolver(envg; backscatter=true, rmax=60.0)
       transmission_loss(pmg, AcousticSource((x=0.0, z=-20.0), 5000.0), AcousticReceiver((x=10.0, z=-20.0)))
     end
     x = [50.0, -20.0, 2.0]

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -217,6 +217,65 @@ end
   end
 end
 
+@testitem "raysolver-curvature-benchmark" begin
+  using UnderwaterAcoustics
+  using UnderwaterAcoustics: absorption
+  if !isdefined(UnderwaterAcoustics, :Scatterer)
+    # awaiting the UnderwaterAcoustics.jl scatterer API (rev 3)
+    @test_skip false
+  else
+    # verify the curved-boundary beam-spreading correction against the mirror
+    # equation (geometric optics, independent of the solver's dynamic ray
+    # tracing): a convex circular reflector transforms the in-plane wavefront
+    # curvature as 1/ρ' = 1/s₁ + 2κ/sinθg
+    c = 1500.0; f = 5000.0; a = 2.0; L = 50.0
+    env = UnderwaterEnvironment(bathymetry=200.0, soundspeed=c,
+      seabed=FluidBoundary(water_density(), c, 0.0),  # non-reflecting
+      scatterers=(Scatterer(Ellipse(L, -100.0, a, a), RigidBoundary),))
+    mid_temp = (minimum(env.temperature) + maximum(env.temperature)) / 2
+    hmax = 200.0
+    tx = AcousticSource(0.0, -100.0, f)
+    pm = RaySolver(env; backscatter=true, rmax=100.0, nbeams=2000)
+    function analytic_echo(txp, rxp)
+      # specular point on the tx-facing half of the circle by Fermat
+      path(u) = begin
+        p = boundary_point(Ellipse(L, -100.0, a, a), u)
+        hypot(p.x - txp[1], p.z - txp[2]) + hypot(p.x - rxp[1], p.z - rxp[2])
+      end
+      lo, hi = 0.25, 0.75
+      φ = (√5 - 1) / 2
+      for _ in 1:200
+        m1 = hi - φ * (hi - lo); m2 = lo + φ * (hi - lo)
+        path(m1) < path(m2) ? (hi = m2) : (lo = m1)
+      end
+      u = (lo + hi) / 2
+      P = boundary_point(Ellipse(L, -100.0, a, a), u)
+      n̂ = (x=(P.x - L)/a, z=(P.z + 100.0)/a)
+      s₁ = hypot(P.x - txp[1], P.z - txp[2])
+      s₂ = hypot(P.x - rxp[1], P.z - rxp[2])
+      t̂ = ((P.x - txp[1])/s₁, (P.z - txp[2])/s₁)
+      sinθg = abs(t̂[1]*n̂.x + t̂[2]*n̂.z)
+      ρ′ = 1 / (1/s₁ + 2/(a*sinθg))          # mirror equation, convex
+      q_rx = s₁ * (ρ′ + s₂) / ρ′             # in-plane spreading at receiver
+      θ₀ = atan(P.z - txp[2], P.x - txp[1])
+      D = s₁ + s₂
+      A = √abs(cos(θ₀) * c / (rxp[1] * c * q_rx)) * absorption(f, D, env.salinity, mid_temp, hmax/2)
+      (A=A, t=D/c)
+    end
+    # normal incidence through strongly oblique (sinθg ≈ 0.93)
+    for rxp ∈ ((10.0, -100.0), (15.0, -92.0), (10.0, -70.0), (5.0, -60.0))
+      arr = arrivals(pm, tx, AcousticReceiver(rxp[1], rxp[2]))
+      ref = analytic_echo((0.0, -100.0), rxp)
+      bck = filter(x -> abs(x.θᵣ) > π/2 && isapprox(x.t, ref.t; atol=2e-4), arr)
+      @test !isempty(bck)
+      if !isempty(bck)
+        m = bck[argmin([abs(x.t - ref.t) for x ∈ bck])]
+        @test abs(m.ϕ) ≈ ref.A rtol=1e-3
+      end
+    end
+  end
+end
+
 @testitem "∂raysolver" begin
   using UnderwaterAcoustics
   using DifferentiationInterface

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -117,6 +117,106 @@ end
   @test xloss[100,100] ≈ 76.6 atol=0.5
 end
 
+@testitem "raysolver-backscatter" begin
+  using UnderwaterAcoustics
+  # null test: with nothing to backscatter, arrivals match the default solver
+  env = UnderwaterEnvironment(bathymetry=20)
+  tx = AcousticSource(0.0, -5.0, 1000.0)
+  rx = AcousticReceiver(100.0, -10.0)
+  arr0 = arrivals(RaySolver(env), tx, rx)
+  pm = @inferred RaySolver(env; backscatter=true)
+  arr1 = arrivals(pm, tx, rx)
+  @test length(arr1) ≥ 7
+  for a0 ∈ arr0[1:7]
+    @test any(a -> isapprox(a.t, a0.t; atol=1e-4) && isapprox(abs(a.ϕ), abs(a0.ϕ); rtol=0.05), arr1)
+  end
+  @test all(a -> abs(a.θᵣ) < π/2, arr1)
+  # bathymetric "wall" behind the receiver: rays travel past the receiver,
+  # reverse off the rigid slope (slope + surface bounce combinations) and
+  # return as backscattered arrivals (|arrival angle| > π/2)
+  bathy = SampledField([20, 20, 1]; x=[0, 85, 100])
+  env2 = UnderwaterEnvironment(bathymetry=bathy, seabed=RigidBoundary, soundspeed=1500.0)
+  tx2 = AcousticSource(0.0, -10.0, 1000.0)
+  rx2 = AcousticReceiver(40.0, -10.0)
+  pm2 = RaySolver(env2; backscatter=true, rmax=100.0)
+  arr2 = arrivals(pm2, tx2, rx2)
+  fwd = sort(filter(a -> abs(a.θᵣ) ≤ π/2, arr2); by=a->a.t)
+  bck = sort(filter(a -> abs(a.θᵣ) > π/2, arr2); by=a->a.t)
+  @test length(fwd) ≥ 3
+  @test length(bck) ≥ 4
+  @test fwd[1].t ≈ 40/1500 atol=1e-4                # direct arrival
+  @test bck[1].t ≈ 0.1106 atol=1e-3                 # earliest wall echo
+  @test bck[1].t > (2*85 - 40)/1500                 # slower than a straight retro-reflection
+  @test abs(bck[1].ϕ) ≈ 0.0114 rtol=0.1             # echo amplitude
+  @test abs(bck[1].ϕ) < abs(fwd[1].ϕ)               # weaker than the direct arrival
+  # all eigenray paths (forward and backscattered) must end at the receiver
+  @test all(a -> abs(a.path[end].x - 40) < 0.5 && abs(a.path[end].z + 10) < 0.5, arr2)
+end
+
+@testitem "∂raysolver-backscatter" begin
+  using UnderwaterAcoustics
+  using DifferentiationInterface
+  import ForwardDiff, FiniteDifferences
+  fd = AutoFiniteDifferences(fdm=FiniteDifferences.central_fdm(5, 1))
+  function ℳ((D, R, d1, d2, f, c))
+    env = UnderwaterEnvironment(bathymetry = D, soundspeed = c, seabed = SandySilt)
+    pm = RaySolver(env; backscatter=true)
+    transmission_loss(pm, AcousticSource((x=0.0, z=-d1), f), AcousticReceiver((x=R, z=-d2)))
+  end
+  x = [20.0, 100.0, 5.0, 10.0, 5000.0, 1500.0]
+  @test gradient(ℳ, AutoForwardDiff(), x) ≈ gradient(ℳ, fd, x) atol=1e-3
+end
+
+@testitem "raysolver-scatterers" begin
+  using UnderwaterAcoustics
+  if !isdefined(UnderwaterAcoustics, :Scatterer)
+    # awaiting the UnderwaterAcoustics.jl scatterer API (rev 3)
+    @test_skip false
+  else
+    # backscatter off a rigid circular scatterer: expect an arrival at
+    # t ≈ (48 + 38) / 1500 (tx at 0, rx at 10, scatterer surface at 48)
+    env = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
+      scatterers = (Scatterer(Ellipse(50.0, -20.0, 2.0, 2.0), RigidBoundary),))
+    tx = AcousticSource(0.0, -20.0, 5000.0)
+    rx = AcousticReceiver(10.0, -20.0)
+    pm = RaySolver(env; backscatter=true)
+    arr = arrivals(pm, tx, rx)
+    bsc = filter(a -> abs(a.θᵣ) > π/2, arr)
+    @test any(a -> isapprox(a.t, 86/1500; atol=1e-3), bsc)
+    # pressure-release scatterer: backscattered arrival flips phase by π
+    env2 = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
+      scatterers = (Scatterer(Ellipse(50.0, -20.0, 2.0, 2.0), PressureReleaseBoundary),))
+    arr2 = arrivals(RaySolver(env2; backscatter=true), tx, rx)
+    bsc2 = filter(a -> abs(a.θᵣ) > π/2, arr2)
+    a1 = bsc[argmin([abs(a.t - 86/1500) for a ∈ bsc])]
+    a2 = bsc2[argmin([abs(a.t - 86/1500) for a ∈ bsc2])]
+    @test abs(angle(a1.ϕ / a2.ϕ)) ≈ π atol=0.1
+    # anti-tunneling: a small scatterer (0.5 m radius) must still be detected
+    env3 = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
+      scatterers = (Scatterer(Ellipse(50.0, -20.0, 0.5, 0.5), RigidBoundary),))
+    arr3 = arrivals(RaySolver(env3; backscatter=true), tx, rx)
+    @test any(a -> abs(a.θᵣ) > π/2 && isapprox(a.t, (49.5 + 39.5)/1500; atol=1e-3), arr3)
+    # shadow: coherent field behind the scatterer drops relative to no-scatterer case
+    env4 = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0)
+    rx2 = AcousticReceiver(60.0, -20.0)
+    tl_free = transmission_loss(RaySolver(env4), tx, rx2)
+    tl_shad = transmission_loss(RaySolver(env; backscatter=true), tx, rx2)
+    @test tl_shad > tl_free
+    # AD through scatterer geometry
+    using DifferentiationInterface
+    import ForwardDiff, FiniteDifferences
+    fd = AutoFiniteDifferences(fdm=FiniteDifferences.central_fdm(5, 1))
+    function ℳ((sx, sz, sa))
+      envg = UnderwaterEnvironment(bathymetry = 40.0, soundspeed = 1500.0,
+        scatterers = (Scatterer(Ellipse(sx, sz, sa, sa), RigidBoundary),))
+      pmg = RaySolver(envg; backscatter=true)
+      transmission_loss(pmg, AcousticSource((x=0.0, z=-20.0), 5000.0), AcousticReceiver((x=10.0, z=-20.0)))
+    end
+    x = [50.0, -20.0, 2.0]
+    @test gradient(ℳ, AutoForwardDiff(), x) ≈ gradient(ℳ, fd, x) atol=1e-3
+  end
+end
+
 @testitem "∂raysolver" begin
   using UnderwaterAcoustics
   using DifferentiationInterface


### PR DESCRIPTION
## Summary

Extends `RaySolver` with two capabilities, designed against the scatterer API in org-arl/UnderwaterAcoustics.jl#86:

1. **Backscatter** (`backscatter=true`): rays that reverse direction (via steep bathymetry or scatterers) keep tracing over a modeling domain `r ∈ [rmin, rmax]` (`rmax=0` → auto = query range, matching the non-backscatter default; `rmin ≤ 0`, default 0) until they exit the domain or drop below `min_amplitude` (including running absorption). Eigenray search handles rays crossing the receiver range multiple times: crossings are recorded exactly by a non-terminating callback event and grouped by *signature* (travel direction + surface/bottom/scatterer bounce history + ordinal), within which the depth error Δz(θ) is continuous, so the existing bracketing/turning-point root-finding applies per signature. Backscattered arrivals are reported with |arrival angle| > π/2. Setting `rmin < 0` extends the domain left of the transmitter and automatically launches a second, mirrored fan of rays in the −x direction so features left of the source can produce echoes (|launch angle| > π/2); x is treated as Cartesian, with |x| in the cylindrical spreading factor. Features outside the domain are invisible — echoes from behind the receivers need an explicit larger `rmax`.

2. **Scatterers**: when the environment carries `scatterers` (UnderwaterAcoustics ≥ 0.8), rays reflect off them like boundaries: specular reflection off the local tangent plane (`boundary_projection`), amplitude via the existing 5-arg `reflection_coef` with the scatterer's `AbstractAcousticBoundary`, and a dynamic-ray-tracing curvature correction to the beam-spreading parameter `p`. Detection runs inside the ODE continuous callback on the signed `distance` field; an anti-tunneling step limiter `dt ≤ 0.9·distance` (valid because the integration variable is arc length and `distance` is 1-Lipschitz) makes it impossible for the solver to step over a small scatterer.

Defaults are fully backward compatible (backscatter off, no scatterers → identical code paths, including the legacy per-segment tspan formula). Works against UnderwaterAcoustics 0.4–0.7 (scatterer support is inert without the new API; verified by running the suite pinned to 0.7.4) and against the `feat-scatterers` branch of #86 (85/85 tests pass).

## Tests

- `raysolver-backscatter`: null test (flat waveguide, backscatter on ≡ off) + bathymetric-wall echo with quantitative time/amplitude/angle checks
- `∂raysolver-backscatter`: ForwardDiff vs FiniteDifferences gradients with backscatter on
- `raysolver-scatterers` (skips when the API is absent): echo time-of-flight off a rigid circle, rigid vs pressure-release π phase flip, anti-tunneling with a 0.5 m target, shadowing, and AD gradients w.r.t. scatterer position/size
- New dependency: DiffEqCallbacks.jl (StepsizeLimiter)

## Amplitude verification

The curved-boundary beam-spreading correction (`p += 2κq/(c·sinθg)`) is verified against an independent analytic benchmark (testitem `raysolver-curvature-benchmark`): the specular point is found by Fermat's principle and the reflected in-plane wavefront curvature by the geometric-optics mirror equation `1/ρ′ = 1/s₁ + 2κ/sinθg`, with no reference to the solver's dynamic ray tracing. Echo amplitudes off a rigid circle match to rtol = 1e-3 at four geometries from normal incidence down to sinθg ≈ 0.93. Arrival times, angles, and phases are verified independently by geometry checks in the other testitems.

## Known limitations

- **Tangent-plane (Kirchhoff) coupling**: valid for ka ≫ 1 and away from grazing; there is no diffraction or creeping-wave contribution, so shadow edges are geometric (softened only by the Gaussian beam width). Low-frequency or small (ka ≲ 1) targets need a target-strength model instead of this boundary-reflection treatment.
- **Grazing incidence**: the curvature correction is skipped below `sinθg = 1e-3`, where the formula genuinely diverges; between sinθg ≈ 0.93 (benchmark coverage) and that cutoff, the correction follows the standard analytic form but is not independently benchmarked.
- **2.5D semantics**: a 2D scatterer with cylindrical out-of-plane spreading models a target extended in the cross-range direction (axisymmetric about the source's vertical axis), not a compact 3D body — a real sphere's target strength is not reproduced. Backscattered rays returning toward the source axis inherit the axisymmetric focusing of the 1/√r factor.
- **Eigenray search resolution**: echoes off small scatterers subtend narrow launch-angle windows; the default `nbeams` heuristic may miss them entirely (increase `nbeams`, e.g. a few thousand, when scatterer echoes matter). The Gaussian-beam grid field does not suffer from this — it deposits whatever the fan traces.
- **Backscatter domain**: rays exiting `r ∈ [rmin, rmax]` are assumed never to return; anything reflective outside the domain is invisible. With the defaults (`rmin = 0`, `rmax` = query range), features behind the receivers or left of the transmitter require explicitly extending the domain.
- **CI note**: the scatterer tests activate only once org-arl/UnderwaterAcoustics.jl#86 merges and 0.8 is registered; until then they self-skip (suite passes on UnderwaterAcoustics 0.4–0.7, verified against 0.7.4) and the `0.8` compat entry is inert.



## Suggested technical follow-ups (non-blocking)

- **Grazing-angle benchmark coverage**: the curvature correction is benchmarked down to sinθg ≈ 0.93; extend the analytic comparison toward grazing if scattered levels near grazing become important.
- **Target-strength model for small ka**: the tangent-plane coupling is wrong for ka ≲ 1; a scattering-function/target-strength object on the scatterer would cover compact/low-frequency targets.
- **Penetrable boundaries**: spawn transmitted rays at fluid boundaries (queue-based `_trace`, Snell refraction, transmission coefficients, interior media, and the dynamic-ray-tracing transmission transform for p/q); design sketch discussed, needs an interior-medium concept in UnderwaterAcoustics.
- **Broad-phase acceleration**: current scatterer distance query is a linear sweep with bbox rejection — fine for ≲ 32 scatterers; a uniform spatial hash built at `ScattererSet` construction is the drop-in upgrade for larger counts.
- **`nbeams` auto-scaling**: the default fan heuristic ignores scatterers; echoes off small targets subtend narrow launch-angle windows and need `nbeams` of a few thousand. The heuristic could scale with the minimum scatterer angular subtense.



