### PR TITLE
Curved-boundary reflections via the field derivative API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -16,12 +15,11 @@ UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 DiffEqCallbacks = "4.18.2"
-ForwardDiff = "1.3.3"
 LinearAlgebra = "1"
 NonlinearSolve = "4"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqRosenbrock = "2.1.0"
 SciMLBase = "3.11.0"
 StaticArrays = "1.9.18"
-UnderwaterAcoustics = "0.4,0.5,0.6,0.7,0.8"
+UnderwaterAcoustics = "0.8"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -15,6 +16,7 @@ UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 DiffEqCallbacks = "4.18.2"
+ForwardDiff = "1.3.3"
 LinearAlgebra = "1"
 NonlinearSolve = "4"
 OrdinaryDiffEq = "7"

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -4,7 +4,6 @@ import OrdinaryDiffEqRosenbrock: Rosenbrock23
 import DiffEqCallbacks: StepsizeLimiter
 import NonlinearSolve: IntervalNonlinearProblem, NonlinearProblem
 import SciMLBase: successful_retcode, terminate!, remake
-import ForwardDiff: derivative
 import ForwardDiff
 import StaticArrays: SA, SVector
 
@@ -410,8 +409,8 @@ end
 # prepare to trace a ray segment
 function _prepare_trace(T, pm)
   c = z -> value(pm.env.soundspeed, z)
-  ∂c = z -> derivative(c, z)
-  ∂²c = z -> derivative(∂c, z)
+  ∂c = z -> ∂(pm.env.soundspeed, z, :z)
+  ∂²c = z -> ∂(pm.env.soundspeed, z, :z, :z)
   ODEProblem{false}(_∂u, zeros(SVector{7,T}), (zero(T), one(T)), (c, ∂c, ∂²c))
 end
 
@@ -458,6 +457,28 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
     soln = solve(prob, pm.solver; abstol=pm.solver_tol, saveat=ds, callback=cbs)
   end
   (soln.t, soln.u)
+end
+
+# dynamic ray tracing correction to the spreading rate p (= qp) for reflection
+# off a (possibly curved) boundary in a medium with a soundspeed gradient
+# [COA (3.123-3.128); Müller, Geoph. J. R.A.S. 79 (1984); BELLHOP Reflect2D].
+# t̂ is the incident unit ray tangent, n̂ the boundary unit normal pointing into
+# the water, κ the boundary curvature (positive where the boundary is convex
+# toward the water), and gc the soundspeed gradient (∂c/∂x, ∂c/∂z) at the
+# reflection point. The correction diverges at grazing incidence and is
+# skipped for sinθg ≤ 1e-3, consistent with the eigenray search tolerances.
+function _reflect_pq(qp, q, c, t̂, n̂, κ, gc)
+  Th = dot(t̂, n̂) / c                    # normal component of the 1/c-scaled tangent
+  abs(Th) * c ≤ 1e-3 && return qp
+  Tg = (t̂[1] * n̂[2] - t̂[2] * n̂[1]) / c  # tangential component (t̂b = (n̂z, -n̂x))
+  t̂′ = t̂ - 2 * dot(t̂, n̂) * n̂
+  rayn = SA[-t̂[2], t̂[1]]                # ray-centred unit normals
+  rayn′ = SA[t̂′[2], -t̂′[1]]             # (reflected frame has opposite sense)
+  cnjump = -dot(gc, rayn′ - rayn)
+  csjump = -dot(gc, t̂′ - t̂)
+  RM = Tg / Th
+  RN = -2κ / (c^2 * Th) + RM * (2 * cnjump - RM * csjump) / c^2
+  qp + q * RN
 end
 
 # trace a ray starting at tx1 with angle θ until it reaches rmax. ds controls the
@@ -548,24 +569,35 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
       ρ = value(pm.env.density, (r, 0.0, z))
       c = value(pm.env.soundspeed, (r, 0.0, z))
       A *= reflection_coef(sca.boundary, f, asin(sinθg), ρ, c)
-      # dynamic ray tracing correction for reflection off a curved boundary
-      # [COA (3.123-3.128)]; skipped near grazing where the correction diverges
-      sinθg > 1e-3 && (qp += q * 2 * hit.curvature / (c * sinθg))
+      gz = ∂(pm.env.soundspeed, z, :z)
+      qp = _reflect_pq(qp, q, c, t̂, n̂, hit.curvature, SA[zero(gz), gz])
       guard = 2 * one(T) * pm.atol
     elseif ev == 1 && isapprox(z, zmax; atol=1e-3)   # hit the surface
       s += 1
       ρ = value(pm.env.density, (r, 0.0, 0.0))
       c = value(pm.env.soundspeed, (r, 0.0, 0.0))
       A *= reflection_coef(pm.env.surface, f, π/2 - θ, ρ, c)
-      α = atan(derivative(x -> value(pm.env.altimetry, (x, 0.0, 0.0)), r))
-      θ = -θ + 2α
+      a′ = ∂(pm.env.altimetry, (r, 0.0, 0.0), :x)
+      a″ = ∂(pm.env.altimetry, (r, 0.0, 0.0), :x, :x)
+      m = √(1 + a′^2)
+      κ = a″ / m^3                       # positive: boundary convex into the water
+      n̂ = SA[a′, -one(a′)] / m           # unit normal pointing into the water
+      gz = ∂(pm.env.soundspeed, z, :z)
+      qp = _reflect_pq(qp, q, c, SA[cos(θ), sin(θ)], n̂, κ, SA[zero(gz), gz])
+      θ = -θ + 2atan(a′)
     elseif ev == 2 && isapprox(z, zmin; atol=1e-3)   # hit the bottom
       b += 1
       ρ = value(pm.env.density, (r, 0.0, z))
       c = value(pm.env.soundspeed, (r, 0.0, z))
       A *= reflection_coef(pm.env.seabed, f, π/2 + θ, ρ, c)
-      α = atan(derivative(x -> value(pm.env.bathymetry, (x, 0.0, 0.0)), r))
-      θ = -θ - 2α
+      d′ = ∂(pm.env.bathymetry, (r, 0.0, 0.0), :x)
+      d″ = ∂(pm.env.bathymetry, (r, 0.0, 0.0), :x, :x)
+      m = √(1 + d′^2)
+      κ = d″ / m^3                       # positive: boundary convex into the water
+      n̂ = SA[d′, one(d′)] / m            # unit normal pointing into the water
+      gz = ∂(pm.env.soundspeed, z, :z)
+      qp = _reflect_pq(qp, q, c, SA[cos(θ), sin(θ)], n̂, κ, SA[zero(gz), gz])
+      θ = -θ - 2atan(d′)
     else
       break
     end

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -294,6 +294,84 @@ end
   end
 end
 
+@testitem "raysolver-boundary-curvature" begin
+  using UnderwaterAcoustics
+  if !isdefined(UnderwaterAcoustics, :∂)
+    # awaiting the UnderwaterAcoustics.jl field derivative API
+    @test_skip false
+  else
+    # ray-tube consistency: for a point source, the dynamic ray tracing q at
+    # the end of a ray equals the perpendicular ray-tube width per unit launch
+    # angle at fixed range. This must hold across
+    # reflections off curved boundaries (curvature term) and off flat/curved
+    # boundaries in a soundspeed-gradient medium (Müller cn/cs jump terms).
+    import AcousticRayTracers
+    struct ParabolicBathy <: UnderwaterAcoustics.PositionDependent
+      D::Float64    # depth at x = xm
+      xm::Float64
+      R::Float64    # radius of curvature (> 0: seamount, < 0: basin)
+    end
+    (b::ParabolicBathy)(pos::XYZ) = b.D + (pos.x - b.xm)^2 / (2 * b.R)
+    Base.minimum(b::ParabolicBathy) = b.R > 0 ? b.D : b.D - 100.0
+    Base.maximum(b::ParabolicBathy) = b.R > 0 ? b.D + 100.0 : b.D
+    struct ParabolicSurf <: UnderwaterAcoustics.PositionDependent
+      a::Float64    # altitude at x = xm
+      xm::Float64
+      R::Float64
+    end
+    (s::ParabolicSurf)(pos::XYZ) = s.a + (pos.x - s.xm)^2 / (2 * s.R)
+    Base.minimum(s::ParabolicSurf) = min(s.a, s.a + 100.0^2 / (2 * s.R))
+    Base.maximum(s::ParabolicSurf) = max(s.a, s.a + 100.0^2 / (2 * s.R))
+    function q_vs_raytube(env, θ; rmax=100.0, δ=1e-4)
+      pm = RaySolver(env)
+      tx = AcousticSource(0.0, -20.0, 5000.0)
+      trace(ϕ) = AcousticRayTracers._trace(pm, tx, ϕ, rmax; aux=true)
+      arr, aux, _ = trace(θ)
+      @test arr.path[end].x ≈ rmax atol=0.1
+      q = aux[end][2]
+      z(ϕ) = trace(ϕ)[1].path[end].z
+      dzdθ = (z(θ + δ) - z(θ - δ)) / 2δ
+      # ray-centred normal convention makes q = -cos(θᵣ) ∂z/∂θ₀
+      q, -cos(arr.θᵣ) * dzdθ
+    end
+    # curved bottom (seamount, convex into water), isovelocity
+    env = UnderwaterEnvironment(bathymetry=ParabolicBathy(60.0, 50.0, 200.0),
+      soundspeed=1500.0, seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, -deg2rad(40))
+    @test q ≈ qfd rtol=1e-3
+    # curved bottom (basin, concave into water), isovelocity
+    env = UnderwaterEnvironment(bathymetry=ParabolicBathy(60.0, 50.0, -500.0),
+      soundspeed=1500.0, seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, -deg2rad(40))
+    @test q ≈ qfd rtol=1e-3
+    # flat bottom, soundspeed gradient (tests the cn/cs jump terms alone)
+    env = UnderwaterEnvironment(bathymetry=60.0,
+      soundspeed=SampledField([1540.0, 1500.0]; z=[0.0, -60.0]), seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, -deg2rad(40))
+    @test q ≈ qfd rtol=1e-3
+    # curved bottom + soundspeed gradient (both corrections together); the SSP
+    # spans deeper than the bottom so that rays never cross the SSP knot, where
+    # the gradient discontinuity would need a (unimplemented) transmission
+    # correction to p that is unrelated to boundary reflections
+    env = UnderwaterEnvironment(bathymetry=ParabolicBathy(60.0, 50.0, 200.0),
+      soundspeed=SampledField([1540.0, 1490.0]; z=[0.0, -75.0]), seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, -deg2rad(40))
+    @test q ≈ qfd rtol=1e-3
+    # flat surface, soundspeed gradient (cn/cs jump terms, top reflection)
+    env = UnderwaterEnvironment(bathymetry=200.0,
+      soundspeed=SampledField([1540.0, 1500.0]; z=[0.0, -60.0]), seabed=RigidBoundary)
+    # (looser tolerance: the FD reference is limited by ODE solver error near
+    # the post-reflection restart at the surface)
+    q, qfd = q_vs_raytube(env, deg2rad(30))
+    @test q ≈ qfd rtol=5e-3
+    # curved surface (local sag at x = 50, convex into water), isovelocity
+    env = UnderwaterEnvironment(bathymetry=200.0, altimetry=ParabolicSurf(-0.5, 50.0, 400.0),
+      soundspeed=1500.0, seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, deg2rad(30))
+    @test q ≈ qfd rtol=1e-3
+  end
+end
+
 @testitem "∂raysolver" begin
   using UnderwaterAcoustics
   using DifferentiationInterface
@@ -320,4 +398,35 @@ end
   ∇ℳ₂ = gradient(ℳ₂, fd, x)
   @test gradient(ℳ₁, AutoForwardDiff(), x) ≈ ∇ℳ₁ atol=1e-3
   @test gradient(ℳ₂, AutoForwardDiff(), x) ≈ ∇ℳ₂ atol=1e-3
+  # sampled (piecewise linear) SSP: the analytic field-derivative path
+  # (including knot conventions) must produce the same gradients through a
+  # full trace as an equivalent hand-written piecewise-linear field that uses
+  # the generic AD fallback. (An FD reference is unusable here: with a
+  # refracting SSP, finite differences pick up the derivative of the ODE
+  # discretization error, which the default solver tolerance leaves at ~1e-3.)
+  struct PiecewiseLinearSSP{T} <: UnderwaterAcoustics.DepthDependent
+    v::Vector{T}
+  end
+  function (s::PiecewiseLinearSSP)(pos::UnderwaterAcoustics.XYZ)
+    z = clamp(pos.z, -20.0, 0.0)   # match SampledField's Flat() extrapolation
+    z ≥ -10.0 ? s.v[1] + (s.v[2] - s.v[1]) * z / -10.0 :
+                s.v[2] + (s.v[3] - s.v[2]) * (z + 10.0) / -10.0
+  end
+  Base.minimum(s::PiecewiseLinearSSP) = minimum(s.v)
+  Base.maximum(s::PiecewiseLinearSSP) = maximum(s.v)
+  # observable: ray endpoint depth for a fixed launch angle — smooth in the
+  # SSP samples, so it isolates the derivative path from eigenray-search and
+  # coherent-summation noise (rounding differences between the two SSP
+  # implementations still perturb the adaptive ODE steps, hence atol 1e-3)
+  function ℳ₃(v, ssp)
+    env = UnderwaterEnvironment(bathymetry = 20.0, soundspeed = ssp, seabed = SandySilt)
+    pm = RaySolver(env)
+    tx = AcousticSource((x=0.0, z=-5.0), 5000.0)
+    AcousticRayTracers._trace(pm, tx, -deg2rad(30), 100.0)[1].path[end].z
+  end
+  import AcousticRayTracers
+  x = [1500.0, 1490.0, 1510.0]
+  g1 = gradient(v -> ℳ₃(v, SampledField([v[1], v[2], v[3]]; z=[0.0, -10.0, -20.0])), AutoForwardDiff(), x)
+  g2 = gradient(v -> ℳ₃(v, PiecewiseLinearSSP([v[1], v[2], v[3]])), AutoForwardDiff(), x)
+  @test g1 ≈ g2 atol=1e-3
 end


### PR DESCRIPTION
## Summary

Addresses #19 and #20, building on the scatterer support from #22 and on org-arl/UnderwaterAcoustics.jl#90 (the `∂` field derivative API).

- **#20**: `_prepare_trace` and the boundary-slope computations now use `∂(field, pos, i[, j])` instead of nested `ForwardDiff.derivative` over `value()`. With `SampledField` profiles this hits the analytic derivative path with well-defined knot conventions; the direct ForwardDiff dependency is dropped and UnderwaterAcoustics compat narrowed to 0.8.
- **#19**: new `_reflect_pq` applies the full dynamic ray tracing reflection correction to the spreading rate — boundary curvature **and** the Müller soundspeed-gradient jump terms [COA (3.123–3.128); BELLHOP `Reflect2D`] — uniformly at surface, bottom, and scatterer bounces. Surface/bottom slope and curvature come from `∂(altimetry/bathymetry, ⋅, :x[, :x])`; the scatterer bounce from #22 is refactored into the same helper (its κ-only term is the isovelocity special case).

## Testing

- New `raysolver-boundary-curvature` testitem: ray-tube consistency — the dynamic-ray-tracing `q` must equal the finite-difference ray-tube width per unit launch angle. Covered: convex (seamount) and concave (basin) bottoms, a curved surface, flat bottom & surface in a gradient medium, and curvature+gradient combined (agreement typically ~1e-4 relative). This test caught a genuine sign error in the gradient jump terms during development.
- `∂raysolver` gains an AD-equivalence guardrail: gradients w.r.t. SSP sample values through a full trace match between a `SampledField` (analytic `∂` path) and an equivalent hand-written piecewise-linear field (generic AD path). An FD reference is not usable for refracting SSPs — finite differences pick up the derivative of the ODE discretization error at the default solver tolerance.
- Full local suite passes (100 assertions + Aqua) with UnderwaterAcoustics master + #90 dev'ed. **CI will fail until UnderwaterAcoustics 0.8 (incl. #90) is registered**, since the `∂` API is a hard requirement (compat `0.8`).

Found along the way and filed separately: #24 (missing transmission correction to `p` where a piecewise-linear SSP has gradient discontinuities).