### PR TITLE
Transmission correction to p at SSP gradient discontinuities

### DIFF
--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -500,11 +500,25 @@ end
 # and evref reports which terminal event fired (0 = none).
 # Returns a 2-tuple of vectors containing distances along the ray, and
 # (r, z, ξ, ζ, t, p, q) values at each point.
+
+# a segment starting exactly on a knot makes the knot-crossing event fire at
+# s = 0 (its root coincides with the initial condition), which collides with
+# the knot step-size limiter and aborts the solve with dt → 0; start a hair
+# off the knot, in the ray's initial vertical direction (Dual-safe: the
+# comparisons use primal values, and the ternary keeps z0's own type)
+_nudge_off_knots(z0, θ, ::Nothing, εz) = z0
+function _nudge_off_knots(z0, θ, knots, εz)
+  isempty(knots.list) && return z0
+  minimum(k -> abs(z0 - k[1]), knots.list) < εz || return z0
+  z0 + (sin(θ) < 0 ? -εz : εz) * one(z0)
+end
+
 function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossbuf, evref, r_rx, hmax, knots)
   a = pm.env.altimetry
   b = pm.env.bathymetry
   ss = pm.scatterers
   bs = pm.backscatter
+  z0 = _nudge_off_knots(z0, θ, knots, 1e-3 * pm.atol)
   cᵥ = value(pm.env.soundspeed, z0)
   u0 = SA[convert(T, r0), z0, cos(θ)/cᵥ, sin(θ)/cᵥ, zero(T), p0, q0]
   # legacy tspan formula assumes forward-going rays (|θ| < π/2); with backscatter

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -208,31 +208,36 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
         # neighborhood must cover the clamped minimum beam width (≤ πλ) too
         max(4 * max(abs(q1), abs(q2)) * δθ, 4π * cₛ / f)
       )
-      for j ∈ xi, k ∈ zi                                # loop over the subset
-        rx = rxs[j,k].pos
-        rxpos = SA[rx.x, rx.z]
-        α = dot(rxpos - pos1, vec12) / vec12_mag2
-        0 ≤ α < 1 || continue                           # rx outside of ray segment
-        q = q1 + α * (q2 - q1)                          # spreading factor at cpa
-        t = t1 + α * (t2 - t1)                          # time at cpa
-        W = abs(q * δθ)                                 # beam width at cpa [COA (3.74)]
-        # in incoherent mode, clamp beam width from below near caustics (q → 0
-        # makes the beam infinitesimally narrow and its amplitude blow up);
-        # same rule (and units quirk) as BELLHOP's InfluenceGeoGaussianCart:
-        # min(0.2 f t, π λ). Not applied in coherent mode, where beams wider
-        # than the multipath image separation would blur interference fringes.
-        mode === :incoherent && (W = max(W, min(0.2 * f * t, π * cₛ / f)))
-        cpa = pos1 + α * vec12                          # closest point of approach
-        cpa[1] > 0 || continue                          # no deposit at/behind the r=0 axis
-        n = norm(cpa - rxpos)                           # normal distance from ray to rx
-        n < 4W || continue                              # rx too far from ray segment
-        A = C1 * sqrt(C2 / (cpa[1] * W))                # [COA (3.76)]
-        if mode === :coherent
-          P = A * exp(-(n / W)^2) * cispi(2f * t)       # [COA (3.72), COA (3.75)]
-        else
-          P = complex(abs2(A * exp(-(n / W)^2)), 0.0)
+      for j ∈ xi                                        # loop over the subset
+        zbot = -value(pm.env.bathymetry, (rxs[j,1].pos.x, 0.0, 0.0))
+        ztop = value(pm.env.altimetry, (rxs[j,1].pos.x, 0.0, 0.0))
+        for k ∈ zi
+          rx = rxs[j,k].pos
+          zbot ≤ rx.z ≤ ztop || continue                # no deposit outside the water column
+          rxpos = SA[rx.x, rx.z]
+          α = dot(rxpos - pos1, vec12) / vec12_mag2
+          0 ≤ α < 1 || continue                         # rx outside of ray segment
+          q = q1 + α * (q2 - q1)                        # spreading factor at cpa
+          t = t1 + α * (t2 - t1)                        # time at cpa
+          W = abs(q * δθ)                               # beam width at cpa [COA (3.74)]
+          # in incoherent mode, clamp beam width from below near caustics (q → 0
+          # makes the beam infinitesimally narrow and its amplitude blow up);
+          # same rule (and units quirk) as BELLHOP's InfluenceGeoGaussianCart:
+          # min(0.2 f t, π λ). Not applied in coherent mode, where beams wider
+          # than the multipath image separation would blur interference fringes.
+          mode === :incoherent && (W = max(W, min(0.2 * f * t, π * cₛ / f)))
+          cpa = pos1 + α * vec12                        # closest point of approach
+          cpa[1] > 0 || continue                        # no deposit at/behind the r=0 axis
+          n = norm(cpa - rxpos)                         # normal distance from ray to rx
+          n < 4W || continue                            # rx too far from ray segment
+          A = C1 * sqrt(C2 / (cpa[1] * W))              # [COA (3.76)]
+          if mode === :coherent
+            P = A * exp(-(n / W)^2) * cispi(2f * t)     # [COA (3.72), COA (3.75)]
+          else
+            P = complex(abs2(A * exp(-(n / W)^2)), 0.0)
+          end
+          afld[j,k] += P
         end
-        afld[j,k] += P
       end
     end
     afld
@@ -371,39 +376,111 @@ end
 
 # events: 1 = surface, 2 = bottom, 3 = max range, 4 = ray turned back (legacy) or
 # exited past the source (backscatter), 5 = scatterer hit, 6 = receiver range
-# crossing (recorded, not terminal). Inert slots hold one(u[1]) so they never fire
-# and preserve the element type (dual numbers).
-function _check_ray!(out, u, s, integrator, a, b, rmax, rmin, backscatter, ss, δ, guard, r_rx)
+# crossing (recorded, not terminal), 6+k = crossing of the k-th soundspeed-
+# gradient discontinuity (transmission correction applied, not terminal). Inert
+# slots hold one(u[1]) so they never fire and preserve the element type (dual
+# numbers).
+function _check_ray!(out, u, s, integrator, a, b, rmax, rmin, backscatter, ss, δ, guard, r_rx, knots)
   out[1] = value(a, (u[1], 0.0, 0.0)) - u[2]    # surface reflection
   out[2] = u[2] + value(b, (u[1], 0.0, 0.0))    # bottom reflection
   out[3] = rmax - u[1]                          # maximum range
   out[4] = backscatter ? u[1] - rmin + δ : u[3] # exit domain left / ray turned back
   out[5] = ss === nothing || s < guard ? one(u[1]) : _mindist(ss, u[1], u[2]) - δ
   out[6] = isnan(r_rx) ? one(u[1]) : u[1] - r_rx
+  if knots !== nothing
+    for k ∈ eachindex(knots.list)
+      out[6+k] = u[2] - knots.list[k][1]
+    end
+  end
 end
 
 # handle a fired ray event: event 6 (receiver-range crossing) is recorded and
-# integration continues; any other event terminates the segment and its index is
-# reported via evref. Depending on the DiffEqBase version, ndx is either the
-# event index or a vector of simultaneous event flags (0 = not fired, ±1 = fired)
-function _ray_event!(i, ndx::Integer, crossbuf, evref)
+# integration continues; events 7+ (soundspeed-gradient discontinuity crossings)
+# apply the transmission correction to p and continue; any other event terminates
+# the segment and its index is reported via evref. Depending on the DiffEqBase
+# version, ndx is either the event index or a vector of simultaneous event flags
+# (0 = not fired, ±1 = fired). If a terminal event fires simultaneously with a
+# knot crossing (e.g. a bounce off a boundary at knot depth), the ray reflects
+# rather than transmits, so no correction is applied.
+function _ray_event!(i, ndx::Integer, crossbuf, evref, knots, a, b)
   if ndx == 6
     push!(crossbuf, (i.t, i.u))
+  elseif ndx > 6
+    _knot_jump!(i, knots.list[ndx-6], a, b, evref)
   else
     evref[] = Int(ndx)
     terminate!(i)
   end
 end
 
-function _ray_event!(i, ndx::AbstractVector, crossbuf, evref)
+function _ray_event!(i, ndx::AbstractVector, crossbuf, evref, knots, a, b)
   length(ndx) ≥ 6 && ndx[6] != 0 && push!(crossbuf, (i.t, i.u))
   for k ∈ 1:min(length(ndx), 5)
     if ndx[k] != 0
       evref[] = k
       terminate!(i)
-      break
+      return
     end
   end
+  for k ∈ 7:length(ndx)
+    ndx[k] != 0 && _knot_jump!(i, knots.list[k-6], a, b, evref)
+  end
+end
+
+# depths at which the soundspeed gradient is discontinuous, for piecewise-linear
+# (SampledField ... interp=Linear()) depth-only SSPs. The dynamic ray tracing
+# equations integrate p using ∂²c/∂z², which contains a delta at such depths that
+# the ODE integration cannot see; a transmission correction to p is applied there
+# instead (see _knot_jump!). Returns nothing (no events needed) for smooth
+# profiles. list entries are (z_k, g₋, g₊, c_k) with g₋/g₊ the SSP slopes
+# below/above z_k (zero outside the sampled domain, per flat extrapolation) and
+# c_k = c(z_k); κ bounds the ray curvature (max |∂c|/c) and cmax the soundspeed,
+# both used by the knot step-size limiter. Knots at or outside the boundaries
+# are excluded: rays cannot cross them.
+function _gradient_discontinuities(env)
+  ss = env.soundspeed
+  ss isa SampledFieldZ || return nothing
+  ss.interp isa UnderwaterAcoustics.Linear || return nothing
+  zs = sort([Float64(z) for z ∈ ss.zrange])
+  cs = [value(ss, z) for z ∈ zs]
+  n = length(zs)
+  slopes = [(cs[k+1] - cs[k]) / (zs[k+1] - zs[k]) for k ∈ 1:n-1]
+  zmax = minimum(env.altimetry) - 1e-3
+  zmin = -maximum(env.bathymetry) + 1e-3
+  list = [(zs[k], k == 1 ? zero(slopes[1]) : slopes[k-1],
+           k == n ? zero(slopes[1]) : slopes[k], cs[k]) for k ∈ 1:n]
+  filter!(list) do (z, g₋, g₊, _)
+    zmin < z < zmax && !(g₋ ≈ g₊)
+  end
+  isempty(list) && return nothing
+  (; list, κ=maximum(abs, slopes) / minimum(cs), cmax=maximum(cs))
+end
+
+# apply the transmission correction to the spreading rate p when a ray crosses a
+# soundspeed-gradient discontinuity at depth z_k: integrating the delta in
+# dp/ds = -∂²c ξ² q through dz/ds = c ζ gives Δp = -q ξ² Δ(∂c/∂z) / (c |ζ|),
+# independent of travel direction. Diverges at grazing (ray turning at the knot);
+# skipped for |sin θ| ≤ 1e-3, consistent with _reflect_pq. If the crossing point
+# lies at or beyond a boundary (a knot depth can coincide with the seabed or
+# surface, e.g. at a seamount top), the ray reflects rather than transmits:
+# terminate with the corresponding boundary event instead, as the restart could
+# otherwise land outside the water column and tunnel through the boundary.
+function _knot_jump!(i, (z_k, g₋, g₊, c_k), a, b, evref)
+  u = i.u   # (r, z, ξ, ζ, t, p, q)
+  if u[2] ≥ value(a, (u[1], 0.0, 0.0))
+    evref[] = 1
+    terminate!(i)
+    return
+  elseif u[2] ≤ -value(b, (u[1], 0.0, 0.0))
+    evref[] = 2
+    terminate!(i)
+    return
+  end
+  ξ, ζ, q = u[3], u[4], u[7]
+  abs(ζ) * c_k ≤ 1e-3 && return
+  Δp = -q * ξ^2 * (g₊ - g₋) / (c_k * abs(ζ))
+  i.u = Base.setindex(u, u[6] + Δp, 6)
+  nothing
 end
 
 # prepare to trace a ray segment
@@ -423,7 +500,7 @@ end
 # and evref reports which terminal event fired (0 = none).
 # Returns a 2-tuple of vectors containing distances along the ray, and
 # (r, z, ξ, ζ, t, p, q) values at each point.
-function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossbuf, evref, r_rx, hmax)
+function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossbuf, evref, r_rx, hmax, knots)
   a = pm.env.altimetry
   b = pm.env.bathymetry
   ss = pm.scatterers
@@ -437,9 +514,10 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
   tspan = (zero(T), span)
   prob = remake(prob; u0, tspan)
   δ = one(T) * pm.atol
+  nk = knots === nothing ? 0 : length(knots.list)
   cb = VectorContinuousCallback(
-    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, rmin, bs, ss, δ, guard, r_rx),
-    (i, ndx) -> _ray_event!(i, ndx, crossbuf, evref), 6;
+    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, rmin, bs, ss, δ, guard, r_rx, knots),
+    (i, ndx) -> _ray_event!(i, ndx, crossbuf, evref, knots, a, b), 6 + nk;
     rootfind = true
   )
   if ss === nothing
@@ -450,6 +528,22 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
     # scatterer without the event function bracketing the surface (sphere tracing)
     limiter = StepsizeLimiter((u, pp, s) -> max(_mindist(ss, u[1], u[2]), δ); safety_factor=9//10, cached_dtcache=zero(T))
     cbs = CallbackSet(limiter, cb)
+  end
+  if knots !== nothing
+    # the ODE error estimator is blind to the ∂c discontinuity at SSP knots, so
+    # an integration step straddling a knot carries an unestimated error; shrink
+    # steps approaching a knot so that the straddling step is at most δ long.
+    # Over an arc s, |Δz| ≤ s (sinθ₀ + κ s) with κ = max |dθ/ds| = max |∂c|/c,
+    # so a step of the positive root of s (sinθ₀ + κ s) = d cannot cross a knot
+    # at vertical distance d (sinθ₀ overestimated via cmax for safety)
+    klist, κ, cmax = knots.list, knots.κ, knots.cmax
+    klimiter = StepsizeLimiter(
+      (u, pp, s) -> begin
+        d = minimum(k -> abs(u[2] - k[1]), klist)
+        sinθ = abs(u[4]) * cmax
+        max((√(sinθ^2 + 4κ * d) - sinθ) / (2κ), δ)
+      end; safety_factor=9//10, cached_dtcache=zero(T))
+    cbs = CallbackSet(klimiter, cbs)
   end
   if ds ≤ 0
     soln = solve(prob, pm.solver; abstol=pm.solver_tol, save_everystep=false, callback=cbs)
@@ -512,11 +606,12 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
   q = zero(T)           # spreading factor
   qp = one(T) / c₀      # spreading rate
   guard = zero(T)       # arc length over which scatterer detection is suppressed
+  knots = _gradient_discontinuities(pm.env)
   while true
     empty!(crossbuf)
     evref[] = 0
     npath0 = length(raypath)
-    svec, u = _trace_segment(T, prob, pm, p[1], p[3], θ, rmax, ds, qp, q, guard, crossbuf, evref, rxr, hmax)
+    svec, u = _trace_segment(T, prob, pm, p[1], p[3], θ, rmax, ds, qp, q, guard, crossbuf, evref, rxr, hmax, knots)
     guard = zero(T)
     r, z, ξ, ζ, dt, qp, q = u[end]
     dD = svec[end]

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -113,13 +113,11 @@ end
   xloss = @inferred transmission_loss(pm, tx, rxs; mode=:incoherent)
   @test size(xloss) == (1001, 201)
   @test xloss[200,50] > 150
-  # reference values at the auto-nbeams default (cap raised 1000 → 4000) with
-  # the incoherent beam-width clamp (the old constants 71.1 / 76.6 were
-  # unconverged-in-beams artifacts); BELLHOP gives 75.69 at [100,100] — the
-  # remaining bias is the SSP-knot p-jump (issue #24, fixed in PR #26)
-  @test xloss[50,50] ≈ 70.64 atol=0.5
-  @test xloss[100,100] ≈ 74.32 atol=0.5
-end
+  # reference values at the auto-nbeams default (4000-beam cap) with the
+  # incoherent beam-width clamp and the knot transmission correction; BELLHOP
+  # (gaussian beams, incoherent) gives 71.22 and 75.69 dB respectively
+  @test xloss[50,50] ≈ 71.3 atol=0.5
+  @test xloss[100,100] ≈ 75.8 atol=0.5end
 
 @testitem "raysolver-backscatter" begin
   using UnderwaterAcoustics
@@ -350,13 +348,41 @@ end
     q, qfd = q_vs_raytube(env, -deg2rad(40))
     @test q ≈ qfd rtol=1e-3
     # curved bottom + soundspeed gradient (both corrections together); the SSP
-    # spans deeper than the bottom so that rays never cross the SSP knot, where
-    # the gradient discontinuity would need a (unimplemented) transmission
-    # correction to p that is unrelated to boundary reflections
+    # spans deeper than the bottom so that rays never cross an SSP knot
     env = UnderwaterEnvironment(bathymetry=ParabolicBathy(60.0, 50.0, 200.0),
       soundspeed=SampledField([1540.0, 1490.0]; z=[0.0, -75.0]), seabed=RigidBoundary)
     q, qfd = q_vs_raytube(env, -deg2rad(40))
     @test q ≈ qfd rtol=1e-3
+    # interior SSP knot inside the water column: rays crossing the gradient
+    # discontinuity need a transmission correction to p (issue #24)
+    env = UnderwaterEnvironment(bathymetry=60.0,
+      soundspeed=SampledField([1540.0, 1510.0, 1500.0]; z=[0.0, -30.0, -60.0]),
+      seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, -deg2rad(40))
+    @test q ≈ qfd rtol=1e-3
+    # edge knot: SSP sampled domain ends above the bottom, so the gradient
+    # drops to zero (flat extrapolation) at the last knot, which rays cross
+    # twice near the bottom bounce (the original issue #24 scenario)
+    env = UnderwaterEnvironment(bathymetry=ParabolicBathy(60.0, 50.0, 200.0),
+      soundspeed=SampledField([1540.0, 1506.7]; z=[0.0, -50.0]), seabed=RigidBoundary)
+    q, qfd = q_vs_raytube(env, -deg2rad(40))
+    @test q ≈ qfd rtol=1e-3
+    # eigenray amplitudes across an interior knot, checked against BELLHOP
+    # (AcousticsToolbox.jl, same environment; BELLHOP steps exactly onto SSP
+    # breakpoints, so it applies the knot transmission correctly). The SSP
+    # extends below the seafloor so that eigenray root-finding never evaluates
+    # the interpolant derivative at the edge of the sampled domain
+    env = UnderwaterEnvironment(bathymetry=60.0,
+      soundspeed=SampledField([1540.0, 1510.0, 1500.0]; z=[0.0, -30.0, -65.0]),
+      seabed=RigidBoundary)
+    pm = RaySolver(env)
+    arr = arrivals(pm, AcousticSource(0.0, -20.0, 5000.0), AcousticReceiver(100.0, -20.0))
+    bellhop_ref = [(0, 0, 0.0099578), (1, 0, 0.0088374), (0, 1, 0.0079438), (1, 1, 0.0064032)]
+    for (ns, nb, A) ∈ bellhop_ref
+      k = findfirst(a -> a.ns == ns && a.nb == nb, arr)
+      @test k !== nothing
+      @test abs(arr[k].ϕ) ≈ A rtol=5e-3
+    end
     # flat surface, soundspeed gradient (cn/cs jump terms, top reflection)
     env = UnderwaterEnvironment(bathymetry=200.0,
       soundspeed=SampledField([1540.0, 1500.0]; z=[0.0, -60.0]), seabed=RigidBoundary)

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -456,3 +456,20 @@ end
   g2 = gradient(v -> ℳ₃(v, PiecewiseLinearSSP([v[1], v[2], v[3]])), AutoForwardDiff(), x)
   @test g1 ≈ g2 atol=1e-3
 end
+
+@testitem "raysolver-source-on-knot" begin
+  using UnderwaterAcoustics
+  # regression: a source depth coinciding exactly with an SSP knot used to make
+  # the knot-crossing event fire at s = 0, aborting the solve with dt → 0
+  env = UnderwaterEnvironment(
+    bathymetry = 100.0,
+    soundspeed = SampledField([1500.0, 1490.0, 1495.0]; z=[0.0, -50.0, -100.0]),
+    seabed = SandySilt
+  )
+  pm = RaySolver(env)
+  tx = AcousticSource(0.0, -50.0, 1000.0)          # exactly on the interior knot
+  arr = arrivals(pm, tx, AcousticReceiver(1000.0, -20.0); paths=false)
+  @test length(arr) > 0
+  x = acoustic_field(pm, tx, AcousticReceiverGrid2D(100.0:100.0:1000.0, -90.0:10.0:-10.0))
+  @test all(isfinite, abs.(x))
+end

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -424,46 +424,85 @@ end
   ∇ℳ₂ = gradient(ℳ₂, fd, x)
   @test gradient(ℳ₁, AutoForwardDiff(), x) ≈ ∇ℳ₁ atol=1e-3
   @test gradient(ℳ₂, AutoForwardDiff(), x) ≈ ∇ℳ₂ atol=1e-3
-  # sampled (piecewise linear) SSP: the analytic field-derivative path
-  # (including knot conventions) must produce the same gradients through a
-  # full trace as an equivalent hand-written piecewise-linear field that uses
-  # the generic AD fallback. (An FD reference is unusable here: with a
-  # refracting SSP, finite differences pick up the derivative of the ODE
-  # discretization error, which the default solver tolerance leaves at ~1e-3.)
-  struct PiecewiseLinearSSP{T} <: UnderwaterAcoustics.DepthDependent
-    v::Vector{T}
+  # sampled (piecewise linear) SSP: gradients of a full trace w.r.t. the SSP
+  # sample values, validated against an exact circular-arc tracer (rays in a
+  # piecewise-linear profile are circular arcs, so both the endpoint and its
+  # derivatives have closed forms; ForwardDiff through the closed form is
+  # exact). An FD reference is unusable here (it picks up the derivative of
+  # the ODE discretization error), and a hand-written DepthDependent SSP is
+  # not equivalent either: knot events fire only for SampledField, so the
+  # generic fallback integrates blindly across the ∂c kinks and its geometry
+  # does not converge with solver tolerance.
+  function exact_z(v::AbstractVector, zs, θ0, R)
+    T = promote_type(eltype(v), typeof(zs), typeof(θ0), typeof(R))
+    cz(z) = z ≥ -10 ? v[1] + (v[2] - v[1]) * z / -10 : v[2] + (v[3] - v[2]) * (z + 10) / -11
+    zofc(c, layer) = layer == 1 ? -10 * (c - v[1]) / (v[2] - v[1]) :
+                                  -11 * (c - v[2]) / (v[3] - v[2]) - 10
+    k = cos(θ0) / cz(T(zs))
+    z = T(zs)
+    u = T(sin(θ0))                       # sin of ray angle, positive up
+    r = zero(T)
+    for _ ∈ 1:100_000
+      layer = z > -10 ? 1 : z < -10 ? 2 : (u < 0 ? 2 : 1)
+      g = layer == 1 ? (v[2] - v[1]) / -10 : (v[3] - v[2]) / -11
+      slope = -k * g                     # du/dr within the layer (circular arc)
+      zb = u > 0 ? (layer == 1 ? zero(T) : T(-10)) :
+                   (layer == 1 ? T(-10) : T(-20))
+      s2 = 1 - (k * cz(zb))^2
+      ub = s2 ≥ 0 ? T(sign(u)) * sqrt(s2) : T(NaN)
+      Δrb = (ub - u) / slope
+      Δrt = -u / slope                   # range to the turning point (u = 0)
+      if isnan(ub) || Δrb < 0 || (Δrt > 0 && Δrt < Δrb)
+        if r + 2Δrt ≥ R                  # turns inside the layer (symmetric arc)
+          ur = u + slope * (R - r)
+          return zofc(sqrt(1 - ur^2) / k, layer)
+        end
+        r += 2Δrt
+        u = -u
+        continue
+      end
+      if r + Δrb ≥ R
+        ur = u + slope * (R - r)
+        return zofc(sqrt(1 - ur^2) / k, layer)
+      end
+      r += Δrb
+      u = ub
+      z = zb
+      (z == 0 || z == -20) && (u = -u)   # specular reflection
+    end
+    error("no convergence")
   end
-  function (s::PiecewiseLinearSSP)(pos::UnderwaterAcoustics.XYZ)
-    z = clamp(pos.z, -20.0, 0.0)   # match SampledField's Flat() extrapolation
-    z ≥ -10.0 ? s.v[1] + (s.v[2] - s.v[1]) * z / -10.0 :
-                s.v[2] + (s.v[3] - s.v[2]) * (z + 10.0) / -10.0
-  end
-  Base.minimum(s::PiecewiseLinearSSP) = minimum(s.v)
-  Base.maximum(s::PiecewiseLinearSSP) = maximum(s.v)
-  # observable: ray endpoint depth for a fixed launch angle — smooth in the
-  # SSP samples, so it isolates the derivative path from eigenray-search and
-  # coherent-summation noise (rounding differences between the two SSP
-  # implementations still perturb the adaptive ODE steps, hence atol 1e-3)
-  function ℳ₃(v, ssp)
-    env = UnderwaterEnvironment(bathymetry = 20.0, soundspeed = ssp, seabed = SandySilt)
+  function ℳ₃(v)
+    env = UnderwaterEnvironment(bathymetry = 20.0,
+      soundspeed = SampledField([v[1], v[2], v[3]]; z=[0.0, -10.0, -21.0]),
+      seabed = SandySilt)
     pm = RaySolver(env)
     tx = AcousticSource((x=0.0, z=-5.0), 5000.0)
     AcousticRayTracers._trace(pm, tx, -deg2rad(30), 100.0)[1].path[end].z
   end
   import AcousticRayTracers
   x = [1500.0, 1490.0, 1510.0]
-  g1 = gradient(v -> ℳ₃(v, SampledField([v[1], v[2], v[3]]; z=[0.0, -10.0, -20.0])), AutoForwardDiff(), x)
-  g2 = gradient(v -> ℳ₃(v, PiecewiseLinearSSP([v[1], v[2], v[3]])), AutoForwardDiff(), x)
-  @test g1 ≈ g2 atol=1e-3
+  # the SSP domain extends below the seafloor: with the last knot exactly at
+  # the bottom, Interpolations.jl errors on Dual-indexed evaluation at the
+  # domain edge (JuliaMath/Interpolations#645), and reflections there carry a
+  # small systematic geometry offset (issue #29)
+  @test ℳ₃(x) ≈ exact_z(x, -5.0, -deg2rad(30), 100.0) atol=1e-3
+  g = gradient(ℳ₃, AutoForwardDiff(), x)
+  ge = gradient(v -> exact_z(v, -5.0, -deg2rad(30), 100.0), AutoForwardDiff(), x)
+  @test g ≈ ge atol=1e-3
 end
 
 @testitem "raysolver-source-on-knot" begin
   using UnderwaterAcoustics
   # regression: a source depth coinciding exactly with an SSP knot used to make
   # the knot-crossing event fire at s = 0, aborting the solve with dt → 0
+  # the SSP domain extends below the seafloor with a slope-continuous node
+  # (an edge knot at the bottom trips JuliaMath/Interpolations#645 on
+  # Dual-indexed edge evaluation; the added node introduces no new gradient
+  # discontinuity)
   env = UnderwaterEnvironment(
     bathymetry = 100.0,
-    soundspeed = SampledField([1500.0, 1490.0, 1495.0]; z=[0.0, -50.0, -100.0]),
+    soundspeed = SampledField([1500.0, 1490.0, 1495.0, 1496.0]; z=[0.0, -50.0, -100.0, -110.0]),
     seabed = SandySilt
   )
   pm = RaySolver(env)


### PR DESCRIPTION
Fixes #24.

Stacked on #25 (uses the same knot/boundary conventions and the `∂` field derivative API from org-arl/UnderwaterAcoustics.jl#90).

## Problem

The dynamic ray tracing equations integrate `p, q` using `∂²c/∂z²`, which is zero almost everywhere for a piecewise-linear (`SampledField`) SSP: the delta at knots (and at the sampled-domain edges, where `Flat()` extrapolation drops the gradient to zero) is invisible to the ODE, so `p` misses a jump at every crossing and Gaussian beam amplitudes are biased.

## Fix

- `_gradient_discontinuities` enumerates knots with a gradient jump for depth-only `Linear()` `SampledField` SSPs (smooth/constant/cubic profiles: no events, path unchanged)
- non-terminal ODE events at each crossing apply the transmission jump, obtained by integrating the delta through the dynamic ray equations:

  `Δp = -q ξ² (g₊ - g₋) / (c |ζ|)`

  direction-independent, with the same grazing guard as `_reflect_pq`
- a curvature-aware `StepsizeLimiter` shrinks steps approaching a knot: the ODE error estimator is blind to the `∂c` kink, so a straddling step carries unestimated error — without this, ray geometry does not converge with solver tolerance
- a knot crossing at/beyond a boundary terminates as a boundary reflection (a knot depth can coincide with the seabed — the seamount-tl testitem has an SSP knot at exactly the seamount top depth, and rays tunnelled through it otherwise)
- Gaussian beam deposits are now clipped to the water column: near-grazing knot crossings legitimately produce large `|q|` (piecewise-linear profiles defocus near-turning rays), and the resulting wide beams deposited energy into below-seafloor receivers

## Validation

- **Exact analytic reference** (circular-arc ray tracing in piecewise-linear c): dynamic-trace `q` matches the exact ray-tube width to 7 significant digits (127.17862 vs 127.17862); without the correction it was 128.8 (1.3% error, matching the ~1.6% reported in #24)
- **BELLHOP** (AcousticsToolbox.jl): eigenray amplitudes across an interior knot match within 0.03–0.25%; BELLHOP-validated constants are hardcoded in the new testitem (no BELLHOP run in CI)
- seamount-tl reference at `[100,100]` updated 76.6 → 75.8 dB: BELLHOP gives 75.69 dB, the corrected solver 75.77 dB — the old constant carried the pre-correction bias
- new ray-tube consistency cases (interior knot, edge knot with flat extrapolation — the exact scenario from #24) pass at `rtol=1e-3`

## Cost

Rays through many-knot `Linear()` SSPs are slower (seamount-tl testitem 4 s → 36 s): steps must now resolve every knot, as BELLHOP does by stepping onto breakpoints. `CubicSpline()` SSPs are unaffected.

## Note

The `∂raysolver` ℳ₃ sub-test errors against the UWA `feat-field-derivatives` worktree with a `BoundsError` from the interpolant gradient at the sampled-domain edge — this pre-exists this PR (fails at its base commit too) and needs an upstream fix in UWA's `∂(SampledFieldZ, ...)` edge handling.