### PR TITLE
Eigenray search, auto-nbeams, and incoherent beam-width fixes

### DIFF
--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -57,9 +57,12 @@ Supported keyword arguments:
 - `ds`: nominal spacing between ray points (default: 1/10 water depth)
 - `atol`: absolute position tolerance (default: 0.0001 m)
 - `rugosity`: TODO (default: 1.5)
-- `min_amplitude`: minimum ray amplitude to track (default: 1e-5)
+- `min_amplitude`: minimum ray amplitude to track (default: 1e-6); rays weaker
+  than this (including absorption) stop being traced, which also culls weak
+  multipath from `arrivals` — set to `0.0` to keep all arrivals (e.g. for
+  impulse-response work)
 - `solver`: differential equation solver (default: nothing, auto)
-- `solver_tol`: solver tolerance (default: 1e-4)
+- `solver_tol`: solver tolerance (default: 1e-8)
 - `backscatter`: continue tracing rays that turn back toward the source (default: false)
 - `rmin`: left edge of modeling domain in m, ≤ 0 (default: 0; only meaningful with backscatter)
 - `rmax`: right edge of modeling domain in m (default: 0, auto = query range)

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -5,6 +5,7 @@ import DiffEqCallbacks: StepsizeLimiter
 import NonlinearSolve: IntervalNonlinearProblem, NonlinearProblem
 import SciMLBase: successful_retcode, terminate!, remake
 import ForwardDiff: derivative
+import ForwardDiff
 import StaticArrays: SA, SVector
 
 # scatterers from the environment are wrapped into a ScattererSet at solver
@@ -85,10 +86,15 @@ function UnderwaterAcoustics.arrivals(pm::RaySolver, tx::AbstractAcousticSource,
   _check2d([tx], [rx])
   pm.backscatter && return _arrivals_backscatter(pm, tx, rx; paths, ztol)
   p2 = location(rx)
+  p1 = location(tx)
+  R = abs(p2.x - p1.x)
+  # the interval root-solve tolerance is in launch-angle space, but eigenrays are
+  # accepted on the depth residual (ztol, in m); since dΔz/dθ grows ∝ range, the
+  # angle tolerance must shrink ∝ 1/range or all roots at long range carry
+  # residuals ≫ ztol and are rejected
+  θtol = pm.atol / max(ForwardDiff.value(R), 1.0)   # plain float: solver control, not differentiated
   nbeams = pm.nbeams
   if nbeams == 0
-    p1 = location(tx)
-    R = abs(p2.x - p1.x)
     h = maximum(pm.env.bathymetry)
     nbeams = ceil(Int, 16 * (pm.max_angle - pm.min_angle) / atan(h, R))
   end
@@ -112,7 +118,7 @@ function UnderwaterAcoustics.arrivals(pm::RaySolver, tx::AbstractAcousticSource,
       push!(erays[i], v)
     elseif i > 1 && !isnan(err[i-1]) && !isnan(err[i]) && sign(err[i-1]) * sign(err[i]) < 0
       # rays bracket the receiver, so find a root in between...
-      soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=pm.atol)
+      soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=θtol)
       if successful_retcode(soln.retcode) && abs(soln.resid) < ztol
         push!(erays[i], _trace(pm, tx, soln.u, p2.x, ds; paths)[1])
       end
@@ -649,6 +655,7 @@ end
 # depth error using the same 3-way logic as the forward eigenray search
 function _fan_search(::Type{T2}, pm::RaySolver, tx::AbstractAcousticSource, θ, rdom, r_rx, zrx, ds, ztol, paths) where T2
   T1 = eltype(θ)
+  θtol = pm.atol / max(ForwardDiff.value(abs(r_rx)), 1.0)   # see arrivals: angle tol scales ∝ 1/range
   ntasks = _ntasks(pm)
   crs_all = _tmap(θ1 -> _trace(pm, tx, θ1, rdom; paths=false, r_rx)[3], θ, ntasks)
   allsigs = Set{NTuple{5,Int}}()
@@ -669,7 +676,7 @@ function _fan_search(::Type{T2}, pm::RaySolver, tx::AbstractAcousticSource, θ, 
         v === nothing || push!(results[i], v)
       elseif i > 1 && !isnan(err[i-1]) && !isnan(err[i]) && sign(err[i-1]) * sign(err[i]) < 0
         # crossings bracket the receiver, so find a root in between...
-        soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=pm.atol)
+        soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=θtol)
         if successful_retcode(soln.retcode) && abs(soln.resid) < ztol
           v = _crossing_arrival(pm, tx, soln.u, rdom, r_rx, sig, ds; paths)
           v === nothing || push!(results[i], v)

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -206,7 +206,8 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
       xi, zi = _findall_rxgrid2d(rxs,                   # subset of rx in neighborhood
         ray.path[i].x, ray.path[i+1].x,                 #  of ray segment
         ray.path[i].z, ray.path[i+1].z,
-        4 * max(abs(q1), abs(q2)) * δθ                  # size of neighborhood
+        # neighborhood must cover the clamped minimum beam width (≤ πλ) too
+        max(4 * max(abs(q1), abs(q2)) * δθ, 4π * cₛ / f)
       )
       for j ∈ xi, k ∈ zi                                # loop over the subset
         rx = rxs[j,k].pos
@@ -214,14 +215,20 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
         α = dot(rxpos - pos1, vec12) / vec12_mag2
         0 ≤ α < 1 || continue                           # rx outside of ray segment
         q = q1 + α * (q2 - q1)                          # spreading factor at cpa
+        t = t1 + α * (t2 - t1)                          # time at cpa
         W = abs(q * δθ)                                 # beam width at cpa [COA (3.74)]
+        # in incoherent mode, clamp beam width from below near caustics (q → 0
+        # makes the beam infinitesimally narrow and its amplitude blow up);
+        # same rule (and units quirk) as BELLHOP's InfluenceGeoGaussianCart:
+        # min(0.2 f t, π λ). Not applied in coherent mode, where beams wider
+        # than the multipath image separation would blur interference fringes.
+        mode === :incoherent && (W = max(W, min(0.2 * f * t, π * cₛ / f)))
         cpa = pos1 + α * vec12                          # closest point of approach
         cpa[1] > 0 || continue                          # no deposit at/behind the r=0 axis
         n = norm(cpa - rxpos)                           # normal distance from ray to rx
         n < 4W || continue                              # rx too far from ray segment
         A = C1 * sqrt(C2 / (cpa[1] * W))                # [COA (3.76)]
         if mode === :coherent
-          t = t1 + α * (t2 - t1)                        # time at cpa
           P = A * exp(-(n / W)^2) * cispi(2f * t)       # [COA (3.72), COA (3.75)]
         else
           P = complex(abs2(A * exp(-(n / W)^2)), 0.0)

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -164,7 +164,10 @@ function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticS
     p1 = location(tx)
     R = abs(maximum(rxs.xrange) - p1[1])
     Δz = abs(Float64(rxs.zrange.step))
-    nbeams = clamp(ceil(Int, 8 * (pm.max_angle - pm.min_angle) * R / Δz), 100, 1000)
+    # cap was 1000, but benchmark convergence sweeps vs BELLHOP show deep-water
+    # grids need ~4000 beams (~0.04°/beam over a ±80° fan) to self-converge;
+    # BELLHOP's own auto uses 0.05° spacing
+    nbeams = clamp(ceil(Int, 8 * (pm.max_angle - pm.min_angle) * R / Δz), 100, 4000)
   end
   ds = pm.ds ≤ 0 ? minimum(pm.env.bathymetry) / 10 : pm.ds
   θ = range(pm.min_angle, pm.max_angle; length=nbeams)

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -113,12 +113,12 @@ end
   xloss = @inferred transmission_loss(pm, tx, rxs; mode=:incoherent)
   @test size(xloss) == (1001, 201)
   @test xloss[200,50] > 150
-  # reference values at the auto-nbeams default (cap raised 1000 → 4000; the
-  # old constants 71.1 / 76.6 were unconverged-in-beams artifacts); BELLHOP
-  # gives 75.69 at [100,100] — the remaining bias is the SSP-knot p-jump
-  # (issue #24) and closes to 75.77 with its fix
-  @test xloss[50,50] ≈ 69.98 atol=0.5
-  @test xloss[100,100] ≈ 73.48 atol=0.5
+  # reference values at the auto-nbeams default (cap raised 1000 → 4000) with
+  # the incoherent beam-width clamp (the old constants 71.1 / 76.6 were
+  # unconverged-in-beams artifacts); BELLHOP gives 75.69 at [100,100] — the
+  # remaining bias is the SSP-knot p-jump (issue #24, fixed in PR #26)
+  @test xloss[50,50] ≈ 70.64 atol=0.5
+  @test xloss[100,100] ≈ 74.32 atol=0.5
 end
 
 @testitem "raysolver-backscatter" begin

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -113,8 +113,12 @@ end
   xloss = @inferred transmission_loss(pm, tx, rxs; mode=:incoherent)
   @test size(xloss) == (1001, 201)
   @test xloss[200,50] > 150
-  @test xloss[50,50] ≈ 71.1 atol=0.5
-  @test xloss[100,100] ≈ 76.6 atol=0.5
+  # reference values at the auto-nbeams default (cap raised 1000 → 4000; the
+  # old constants 71.1 / 76.6 were unconverged-in-beams artifacts); BELLHOP
+  # gives 75.69 at [100,100] — the remaining bias is the SSP-knot p-jump
+  # (issue #24) and closes to 75.77 with its fix
+  @test xloss[50,50] ≈ 69.98 atol=0.5
+  @test xloss[100,100] ≈ 73.48 atol=0.5
 end
 
 @testitem "raysolver-backscatter" begin


### PR DESCRIPTION
Fixes for three defects found while systematically benchmarking RaySolver against BELLHOP (`AcousticsToolbox.jl`) across eight scenarios (flat/sloped/seamount bathymetry, iso/gradient/Munk SSPs, referee models where available). Each fix is a separate commit.

## 1. Range-aware eigenray root-solve tolerance
The interval root-solve on launch angle used `abstol = atol` (1e-4) in *angle* space, but eigenrays are accepted on the *depth residual* (`ztol`, meters). `dΔz/dθ` grows ∝ range, so at long range every root carried a residual far above `ztol` and was rejected: at 60 km in a Munk profile, `arrivals` returned **0 of the 16 eigenrays** BELLHOP finds; in a 3 km downward-refracting shallow case, 1 of 18. Scaling the angle tolerance by 1/range recovers 19 (vs BELLHOP's 18) in the shallow case and 4–7 in deep water (the remainder are weak bottom-interacting paths culled by `min_amplitude`, and — behind blocking features — a structural limitation of bracket-based search on discontinuous Δz(θ); a follow-up could reuse the signature-grouped search that `_fan_search!` already implements for backscatter).

## 2. Auto-nbeams cap for grid fields raised 1000 → 4000
Convergence sweeps show deep-water TL grids need ~4000 beams to self-converge; the 1000 cap left the auto default 0.5–2 dB (incoherent) and 2–4 dB (coherent) from converged on 100 km grids. Seamount reference constants updated (old values were unconverged-in-beams artifacts; the new value at [100,100] moves from 76.6 to 74.3, closer to BELLHOP's 75.7, with the remaining bias being issue #24 / PR #26).

## 3. Incoherent Gaussian beam-width clamp (similar to BELLHOP)
Near caustics q → 0 makes deposited beams infinitesimally narrow with diverging amplitude, producing ray-like striations and local blowups in incoherent TL maps. Adopt `InfluenceGeoHatCart`/`InfluenceGeoGaussianCart`'s minimum-width rule `W ≥ min(0.2 f t, π λ)` in incoherent mode only (in coherent mode wide beams would blur interference fringes and break grid-vs-eigenray consistency). Benchmark effect at converged beam counts, incoherent median |ΔTL| vs BELLHOP-gaussian: Munk 50 Hz 0.76 → 0.32 dB, surface duct 0.85 → 0.48 dB, Pekeris 0.58 → 0.45 dB.

Plus a docs commit: `min_amplitude` culls weak multipath from `arrivals` (set `0.0` to keep all, e.g. for impulse responses) and stale docstring defaults corrected.

Full testitem suite passes (including Aqua) with the updated seamount constants; AD guardrail testitems (`∂raysolver`, `∂raysolver-backscatter`) pass — the new tolerance is a plain-float solver control excluded from the derivative path.