### PR TITLE
Eigenray search behind blocking bathymetry, knot geometry convergence, turning-on-knot crash

### DIFF
--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -377,20 +377,29 @@ end
 # events: 1 = surface, 2 = bottom, 3 = max range, 4 = ray turned back (legacy) or
 # exited past the source (backscatter), 5 = scatterer hit, 6 = receiver range
 # crossing (recorded, not terminal), 6+k = crossing of the k-th soundspeed-
-# gradient discontinuity (transmission correction applied, not terminal). Inert
-# slots hold one(u[1]) so they never fire and preserve the element type (dual
-# numbers).
-function _check_ray!(out, u, s, integrator, a, b, rmax, rmin, backscatter, ss, δ, guard, r_rx, knots)
+# gradient discontinuity (transmission correction applied, not terminal),
+# 6+nk+m = crossing of the m-th boundary range-knot (no-op, not terminal: it
+# forces an integration step exactly at the knot so that a boundary vertex —
+# e.g. a seamount peak — cannot be straddled by a single step whose endpoints
+# are both in the water, which would let the ray tunnel through the feature).
+# Inert slots hold one(u[1]) so they never fire and preserve the element type
+# (dual numbers).
+function _check_ray!(out, u, s, integrator, a, b, rmax, rmin, backscatter, ss, δ, guard, r_rx, knots, rknots)
   out[1] = value(a, (u[1], 0.0, 0.0)) - u[2]    # surface reflection
   out[2] = u[2] + value(b, (u[1], 0.0, 0.0))    # bottom reflection
   out[3] = rmax - u[1]                          # maximum range
   out[4] = backscatter ? u[1] - rmin + δ : u[3] # exit domain left / ray turned back
   out[5] = ss === nothing || s < guard ? one(u[1]) : _mindist(ss, u[1], u[2]) - δ
   out[6] = isnan(r_rx) ? one(u[1]) : u[1] - r_rx
+  nk = 0
   if knots !== nothing
-    for k ∈ eachindex(knots.list)
+    nk = length(knots.list)
+    for k ∈ 1:nk
       out[6+k] = u[2] - knots.list[k][1]
     end
+  end
+  for m ∈ eachindex(rknots)
+    out[6+nk+m] = u[1] - rknots[m]
   end
 end
 
@@ -403,8 +412,12 @@ end
 # knot crossing (e.g. a bounce off a boundary at knot depth), the ray reflects
 # rather than transmits, so no correction is applied.
 function _ray_event!(i, ndx::Integer, crossbuf, evref, knots, a, b)
+  nk = knots === nothing ? 0 : length(knots.list)
   if ndx == 6
     push!(crossbuf, (i.t, i.u))
+  elseif ndx > 6 + nk
+    # boundary range-knot crossing: no action needed, the step landing here is
+    # the point (see _check_ray!)
   elseif ndx > 6
     _knot_jump!(i, knots.list[ndx-6], a, b, evref)
   else
@@ -414,6 +427,7 @@ function _ray_event!(i, ndx::Integer, crossbuf, evref, knots, a, b)
 end
 
 function _ray_event!(i, ndx::AbstractVector, crossbuf, evref, knots, a, b)
+  nk = knots === nothing ? 0 : length(knots.list)
   length(ndx) ≥ 6 && ndx[6] != 0 && push!(crossbuf, (i.t, i.u))
   for k ∈ 1:min(length(ndx), 5)
     if ndx[k] != 0
@@ -422,7 +436,7 @@ function _ray_event!(i, ndx::AbstractVector, crossbuf, evref, knots, a, b)
       return
     end
   end
-  for k ∈ 7:length(ndx)
+  for k ∈ 7:min(length(ndx), 6 + nk)
     ndx[k] != 0 && _knot_jump!(i, knots.list[k-6], a, b, evref)
   end
 end
@@ -454,6 +468,22 @@ function _gradient_discontinuities(env)
   end
   isempty(list) && return nothing
   (; list, κ=maximum(abs, slopes) / minimum(cs), cmax=maximum(cs))
+end
+
+# ranges at which the water-column boundaries have slope discontinuities
+# (interior sample points of piecewise-linear SampledField bathymetry or
+# altimetry). Used as no-op ray events so that an integration step cannot
+# straddle a boundary vertex (see _check_ray!). Returns an empty vector when
+# both boundaries are smooth in range.
+function _boundary_range_knots(env)
+  rknots = Float64[]
+  for fld ∈ (env.bathymetry, env.altimetry)
+    fld isa SampledFieldX || continue
+    fld.interp isa UnderwaterAcoustics.Linear || continue
+    xs = sort([Float64(x) for x ∈ fld.xrange])
+    append!(rknots, xs[2:end-1])
+  end
+  sort!(unique!(rknots))
 end
 
 # apply the transmission correction to the spreading rate p when a ray crosses a
@@ -535,7 +565,7 @@ function _nudge_off_knots(z0, θ, knots, εz)
   z0 + (sin(θ) < 0 ? -εz : εz) * one(z0)
 end
 
-function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossbuf, evref, r_rx, hmax, knots)
+function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossbuf, evref, r_rx, hmax, knots, rknots)
   a = pm.env.altimetry
   b = pm.env.bathymetry
   ss = pm.scatterers
@@ -552,8 +582,8 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
   δ = one(T) * pm.atol
   nk = knots === nothing ? 0 : length(knots.list)
   cb = VectorContinuousCallback(
-    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, rmin, bs, ss, δ, guard, r_rx, knots),
-    (i, ndx) -> _ray_event!(i, ndx, crossbuf, evref, knots, a, b), 6 + nk;
+    (out, u, s, i) -> _check_ray!(out, u, s, i, a, b, rmax, rmin, bs, ss, δ, guard, r_rx, knots, rknots),
+    (i, ndx) -> _ray_event!(i, ndx, crossbuf, evref, knots, a, b), 6 + nk + length(rknots);
     rootfind = true
   )
   if ss === nothing
@@ -647,11 +677,12 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
   qp = one(T) / c₀      # spreading rate
   guard = zero(T)       # arc length over which scatterer detection is suppressed
   knots = _gradient_discontinuities(pm.env)
+  rknots = _boundary_range_knots(pm.env)
   while true
     empty!(crossbuf)
     evref[] = 0
     npath0 = length(raypath)
-    svec, u = _trace_segment(T, prob, pm, p[1], p[3], θ, rmax, ds, qp, q, guard, crossbuf, evref, rxr, hmax, knots)
+    svec, u = _trace_segment(T, prob, pm, p[1], p[3], θ, rmax, ds, qp, q, guard, crossbuf, evref, rxr, hmax, knots, rknots)
     guard = zero(T)
     r, z, ξ, ζ, dt, qp, q = u[end]
     dD = svec[end]

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -485,9 +485,31 @@ end
 
 # prepare to trace a ray segment
 function _prepare_trace(T, pm)
-  c = z -> value(pm.env.soundspeed, z)
-  ∂c = z -> ∂(pm.env.soundspeed, z, :z)
-  ∂²c = z -> ∂(pm.env.soundspeed, z, :z, :z)
+  ss = pm.env.soundspeed
+  if ss isa SampledFieldZ && ss.interp isa UnderwaterAcoustics.Linear
+    # where the water column does not extend beyond the sampled domain, evaluate
+    # strictly inside the domain and continue the end segment linearly past its
+    # edge: the field's flat extrapolation zeroes ∂c at/outside the outermost
+    # knots, and when the bathymetry coincides with the last knot this biases
+    # the curvature of every bottom-reflected ray (issue #29); clamping also
+    # avoids Dual-indexed evaluation exactly at the domain edge
+    # (Interpolations.jl #645). Where the water column extends beyond the
+    # domain, the flat-extrapolated region is genuinely reachable and is left
+    # untouched (the edge knot is then handled as a gradient discontinuity).
+    z1, z2 = Float64.(extrema(ss.zrange))
+    zlo = z1 ≤ -maximum(pm.env.bathymetry) + 1e-3 ? z1 + 1e-6 : -Inf
+    zhi = z2 ≥ minimum(pm.env.altimetry) - 1e-3 ? z2 - 1e-6 : Inf
+    c = z -> begin
+      zc = clamp(z, zlo, zhi)
+      value(ss, zc) + ∂(ss, zc, :z) * (z - zc)
+    end
+    ∂c = z -> ∂(ss, clamp(z, zlo, zhi), :z)
+    ∂²c = z -> ∂(ss, clamp(z, zlo, zhi), :z, :z)
+  else
+    c = z -> value(ss, z)
+    ∂c = z -> ∂(ss, z, :z)
+    ∂²c = z -> ∂(ss, z, :z, :z)
+  end
   ODEProblem{false}(_∂u, zeros(SVector{7,T}), (zero(T), one(T)), (c, ∂c, ∂²c))
 end
 
@@ -519,7 +541,7 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
   ss = pm.scatterers
   bs = pm.backscatter
   z0 = _nudge_off_knots(z0, θ, knots, 1e-3 * pm.atol)
-  cᵥ = value(pm.env.soundspeed, z0)
+  cᵥ = prob.p[1](z0)
   u0 = SA[convert(T, r0), z0, cos(θ)/cᵥ, sin(θ)/cᵥ, zero(T), p0, q0]
   # legacy tspan formula assumes forward-going rays (|θ| < π/2); with backscatter
   # or scatterers, use a geometry-based bound instead (segments end at events)
@@ -559,10 +581,13 @@ function _trace_segment(T, prob, pm, r0, z0, θ, rmax, ds, p0, q0, guard, crossb
       end; safety_factor=9//10, cached_dtcache=zero(T))
     cbs = CallbackSet(klimiter, cbs)
   end
+  # reltol must track solver_tol: the ODE-solver default (1e-3) would dominate
+  # abstol for states of O(10+) (depths, ranges) and leave a mm-scale geometry
+  # error floor that no abstol can remove
   if ds ≤ 0
-    soln = solve(prob, pm.solver; abstol=pm.solver_tol, save_everystep=false, callback=cbs)
+    soln = solve(prob, pm.solver; abstol=pm.solver_tol, reltol=pm.solver_tol, save_everystep=false, callback=cbs)
   else
-    soln = solve(prob, pm.solver; abstol=pm.solver_tol, saveat=ds, callback=cbs)
+    soln = solve(prob, pm.solver; abstol=pm.solver_tol, reltol=pm.solver_tol, saveat=ds, callback=cbs)
   end
   (soln.t, soln.u)
 end
@@ -602,7 +627,6 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
   zmin = -hmax
   ϵ = one(zmin) * pm.solver_tol
   p = location(tx1)
-  c₀ = value(pm.env.soundspeed, p)
   T = promote_type(env_type(pm.env), eltype(p), typeof(f), typeof(θ), typeof(rmax), _scat_eltype(pm.scatterers))
   raypath = Array{@NamedTuple{x::T,y::T,z::T}}(undef, 0)
   aux_info = Array{Tuple{T,T,T,Complex{T}}}(undef, 0)
@@ -611,6 +635,8 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
   evref = Ref(0)
   rxr = convert(T, r_rx)
   prob = _prepare_trace(T, pm)
+  cf, ∂cf, _ = prob.p    # domain-safe soundspeed and gradient (see _prepare_trace)
+  c₀ = cf(p.z)
   A = one(Complex{T})   # phasor
   s = 0                 # surface bounces
   b = 0                 # bottom bounces
@@ -676,35 +702,35 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
       θ = atan(t̂′[2], t̂′[1])
       sinθg = clamp(abs(dp), zero(dp), one(dp))
       ρ = value(pm.env.density, (r, 0.0, z))
-      c = value(pm.env.soundspeed, (r, 0.0, z))
+      c = cf(z)
       A *= reflection_coef(sca.boundary, f, asin(sinθg), ρ, c)
-      gz = ∂(pm.env.soundspeed, z, :z)
+      gz = ∂cf(z)
       qp = _reflect_pq(qp, q, c, t̂, n̂, hit.curvature, SA[zero(gz), gz])
       guard = 2 * one(T) * pm.atol
     elseif ev == 1 && isapprox(z, zmax; atol=1e-3)   # hit the surface
       s += 1
       ρ = value(pm.env.density, (r, 0.0, 0.0))
-      c = value(pm.env.soundspeed, (r, 0.0, 0.0))
+      c = cf(zero(z))
       A *= reflection_coef(pm.env.surface, f, π/2 - θ, ρ, c)
       a′ = ∂(pm.env.altimetry, (r, 0.0, 0.0), :x)
       a″ = ∂(pm.env.altimetry, (r, 0.0, 0.0), :x, :x)
       m = √(1 + a′^2)
       κ = a″ / m^3                       # positive: boundary convex into the water
       n̂ = SA[a′, -one(a′)] / m           # unit normal pointing into the water
-      gz = ∂(pm.env.soundspeed, z, :z)
+      gz = ∂cf(z)
       qp = _reflect_pq(qp, q, c, SA[cos(θ), sin(θ)], n̂, κ, SA[zero(gz), gz])
       θ = -θ + 2atan(a′)
     elseif ev == 2 && isapprox(z, zmin; atol=1e-3)   # hit the bottom
       b += 1
       ρ = value(pm.env.density, (r, 0.0, z))
-      c = value(pm.env.soundspeed, (r, 0.0, z))
+      c = cf(z)
       A *= reflection_coef(pm.env.seabed, f, π/2 + θ, ρ, c)
       d′ = ∂(pm.env.bathymetry, (r, 0.0, 0.0), :x)
       d″ = ∂(pm.env.bathymetry, (r, 0.0, 0.0), :x, :x)
       m = √(1 + d′^2)
       κ = d″ / m^3                       # positive: boundary convex into the water
       n̂ = SA[d′, one(d′)] / m            # unit normal pointing into the water
-      gz = ∂(pm.env.soundspeed, z, :z)
+      gz = ∂cf(z)
       qp = _reflect_pq(qp, q, c, SA[cos(θ), sin(θ)], n̂, κ, SA[zero(gz), gz])
       θ = -θ - 2atan(d′)
     else
@@ -717,7 +743,7 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
       abs(A)/abs(q) < pm.min_amplitude && break
     end
   end
-  cₛ = value(pm.env.soundspeed, p)
+  cₛ = cf(p[3])
   A *= √abs(cₛ * cos(θ₀) / (p[1] * c₀ * q))                   # [COA (3.65)]
   A *= absorption(f, D, pm.env.salinity, mid_temp, -zmin/2)   # nominal absorption
   RayArrival(t, A, s, b, θ₀, -θ, raypath), aux_info, crossings

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -338,6 +338,13 @@ end
 function _∂u((r, z, ξ, ζ, t, p, q), (c, ∂c, ∂²c), s)
   # implementation based on [COA (3.161-164, 3.58-63)]
   # assumes range-independent soundspeed
+  if isnan(ForwardDiff.value(z))
+    # a degenerate event rootfind can ask for the RHS at a NaN state; return
+    # NaN (instead of letting the SSP interpolant throw on a NaN index) so the
+    # solver aborts the segment gracefully
+    nan = convert(typeof(z), NaN)
+    return SA[nan, nan, nan, nan, nan, nan, nan]
+  end
   cᵥ = c(z)
   cᵥ² = cᵥ * cᵥ
   c̄ = ∂²c(z) * ξ * ξ

--- a/src/RaySolver.jl
+++ b/src/RaySolver.jl
@@ -90,56 +90,26 @@ function UnderwaterAcoustics.arrivals(pm::RaySolver, tx::AbstractAcousticSource,
   p2 = location(rx)
   p1 = location(tx)
   R = abs(p2.x - p1.x)
-  # the interval root-solve tolerance is in launch-angle space, but eigenrays are
-  # accepted on the depth residual (ztol, in m); since dΔz/dθ grows ∝ range, the
-  # angle tolerance must shrink ∝ 1/range or all roots at long range carry
-  # residuals ≫ ztol and are rejected
-  θtol = pm.atol / max(ForwardDiff.value(R), 1.0)   # plain float: solver control, not differentiated
   nbeams = pm.nbeams
   if nbeams == 0
     h = maximum(pm.env.bathymetry)
     nbeams = ceil(Int, 16 * (pm.max_angle - pm.min_angle) / atan(h, R))
   end
   ds = pm.ds ≤ 0 ? minimum(pm.env.bathymetry) / 10 : pm.ds
-  ntasks = _ntasks(pm)
   θ = range(pm.min_angle, pm.max_angle; length=nbeams)
-  rays = _tmap(θ1 -> _trace(pm, tx, θ1, p2.x)[1], θ, ntasks)
-  err = map(rays) do ray
-    p3 = ray.path[end]
-    isapprox(p3.x, p2.x; atol=pm.atol) && isapprox(p3.y, p2.y; atol=pm.atol) ? p3.z - p2.z : NaN
-  end
+  # eigenrays are found from receiver-range crossings grouped by bounce
+  # signature (_fan_search): with range-dependent bathymetry, adjacent fan rays
+  # can follow different bounce histories (e.g. hit or clear an obstacle), so
+  # the raw depth error Δz(θ) is discontinuous and brackets across a signature
+  # change are meaningless; within one signature Δz(θ) is continuous. Using
+  # crossings (rather than ray endpoints) also finds arrivals on rays that
+  # refract back down-range after passing the receiver.
+  rdom = p2.x + 0.1   # trace slightly past rx so the range crossing is recorded before termination
   T1 = promote_type(env_type(pm.env), eltype(location(tx)), typeof(p2.x), typeof(p2.z))
-  T2 = T1 == eltype(θ) ? eltype(rays) : typeof(_trace(pm, tx, T1(θ[1]), p2.x; paths)[1])
-  prob1 = IntervalNonlinearProblem{false}(_Δz, T1.((θ[1], θ[1])), (pm, tx, p2.x, p2.z))
-  prob2 = NonlinearProblem{false}(_Δz, T1(θ[1]), (pm, tx, p2.x, p2.z))
-  erays = Vector{T2}[T2[] for _ ∈ 1:length(θ)]
-  _tforeach(length(θ), ntasks) do i
-    if isapprox(err[i], 0; atol=pm.atol)
-      # ray already at receiver
-      v = T1 == eltype(θ) ? rays[i] : _trace(pm, tx, T1(θ[i]), p2.x; paths)[1]
-      push!(erays[i], v)
-    elseif i > 1 && !isnan(err[i-1]) && !isnan(err[i]) && sign(err[i-1]) * sign(err[i]) < 0
-      # rays bracket the receiver, so find a root in between...
-      soln = solve(remake(prob1; tspan=T1.(_ordered(θ[i-1], θ[i]))); abstol=θtol)
-      if successful_retcode(soln.retcode) && abs(soln.resid) < ztol
-        push!(erays[i], _trace(pm, tx, soln.u, p2.x, ds; paths)[1])
-      end
-    elseif i > 2 && _isnearzero(err[i-2], err[i-1], err[i])
-      # at a turning point, so potentially two roots between i-2 and i, try and find both...
-      lims = _ordered(θ[i-2], θ[i])
-      soln = solve(remake(prob2; u0=T1(θ[i-1])); abstol=pm.atol)
-      if successful_retcode(soln.retcode) && abs(soln.resid) < ztol && lims[1] < soln.u < lims[2]
-        θ₁ = soln.u
-        push!(erays[i], _trace(pm, tx, θ₁, p2.x, ds; paths)[1])
-        soln = solve(remake(prob2; u0=T1(θ[i-1] < θ₁ ? lims[2] : lims[1])); abstol=pm.atol)
-        if successful_retcode(soln.retcode) && abs(soln.resid) < ztol &&
-           (θ[i-1] < θ₁ ? θ₁ < soln.u < lims[2] : lims[1] < soln.u < θ₁)
-          push!(erays[i], _trace(pm, tx, soln.u, p2.x, ds; paths)[1])
-        end
-      end
-    end
-  end
-  sort!(reduce(vcat, erays); by=Base.Fix2(getfield, :t))
+  T2 = typeof(RayArrival(zero(T1), zero(Complex{T1}), 0, 0, zero(T1), zero(T1),
+    Array{@NamedTuple{x::T1,y::T1,z::T1}}(undef, 0)))
+  erays = _fan_search(T2, pm, tx, collect(T1, θ), T1(rdom), T1(p2.x), T1(p2.z), ds, ztol, paths; edges=true)
+  sort!(erays; by=Base.Fix2(getfield, :t))
 end
 
 function UnderwaterAcoustics.acoustic_field(pm::RaySolver, tx::AbstractAcousticSource, rx::AbstractAcousticReceiver; mode=:coherent)
@@ -780,9 +750,7 @@ function _trace(pm::RaySolver, tx1::AbstractAcousticSource, θ, rmax, ds=0.0; pa
   RayArrival(t, A, s, b, θ₀, -θ, raypath), aux_info, crossings
 end
 
-_Δz(ϕ, (pm, tx1, rmax, z)) = _trace(pm, tx1, ϕ, rmax)[1].path[end].z - z
-
-### backscatter eigenray search
+### eigenray search (signature-grouped; used by both forward and backscatter paths)
 
 # crossings are grouped by "signature" — direction of travel + bounce history —
 # so that the depth error Δz(θ) restricted to one signature is continuous in θ
@@ -813,8 +781,15 @@ function _findsig(crossings, sig)
   nothing
 end
 
-# depth error at the receiver range for the crossing matching sig
+# depth error at the receiver range for the crossing matching sig; NaN when the
+# launch angle is outside the fan (a diverging Newton iteration can probe
+# arbitrary angles, and without backscatter a beyond-vertical angle would give a
+# negative integration span)
 function _Δz_sig(ϕ, (pm, tx1, rdom, r_rx, z, sig))
+  ϕv = ForwardDiff.value(ϕ)
+  if !(pm.backscatter ? -π ≤ ϕv ≤ π : abs(ϕv) < π/2)
+    return convert(promote_type(typeof(ϕ), typeof(z)), NaN)
+  end
   crs = _trace(pm, tx1, ϕ, rdom; paths=false, r_rx)[3]
   i = _findsig(crs, sig)
   i === nothing ? convert(promote_type(typeof(ϕ), typeof(z)), NaN) : crs[i].z - z
@@ -863,10 +838,19 @@ end
 
 # eigenray search over one launch-angle fan: find receiver-range crossings for
 # each launch angle, group by signature, and root-find on the per-signature
-# depth error using the same 3-way logic as the forward eigenray search
-function _fan_search(::Type{T2}, pm::RaySolver, tx::AbstractAcousticSource, θ, rdom, r_rx, zrx, ds, ztol, paths) where T2
+# depth error (exact roots, brackets, and near-turning-point double roots).
+# With edges=true, signature support edges are additionally refined by
+# bisection (issue #31: recovers families whose roots hide between the last
+# supported fan sample and the tangency angle behind a blocking feature); off
+# for backscatter, where the near-tangent grazing arrivals it recovers make
+# the echo field noisy w.r.t. scatterer geometry.
+function _fan_search(::Type{T2}, pm::RaySolver, tx::AbstractAcousticSource, θ, rdom, r_rx, zrx, ds, ztol, paths; edges=false) where T2
   T1 = eltype(θ)
-  θtol = pm.atol / max(ForwardDiff.value(abs(r_rx)), 1.0)   # see arrivals: angle tol scales ∝ 1/range
+  # the interval root-solve tolerance is in launch-angle space, but eigenrays are
+  # accepted on the depth residual (ztol, in m); since dΔz/dθ grows ∝ range, the
+  # angle tolerance must shrink ∝ 1/range or all roots at long range carry
+  # residuals ≫ ztol and are rejected
+  θtol = pm.atol / max(ForwardDiff.value(abs(r_rx)), 1.0)   # plain float: solver control, not differentiated
   ntasks = _ntasks(pm)
   crs_all = _tmap(θ1 -> _trace(pm, tx, θ1, rdom; paths=false, r_rx)[3], θ, ntasks)
   allsigs = Set{NTuple{5,Int}}()
@@ -908,8 +892,88 @@ function _fan_search(::Type{T2}, pm::RaySolver, tx::AbstractAcousticSource, θ, 
           end
         end
       end
+      # support-edge refinement: a signature's θ-support ends where the ray
+      # family becomes tangent to a blocking feature; a root can hide between
+      # the last supported fan sample and that tangency angle (with no second
+      # sample to bracket it). Bisect toward the edge, and root-find on any
+      # sign change encountered on the way.
+      if edges && !isnan(err[i]) && !isapprox(err[i], 0; atol=pm.atol)
+        for j ∈ (i-1, i+1)
+          1 ≤ j ≤ length(θ) && isnan(err[j]) || continue
+          θr = _edge_root(θ[i], θ[j], err[i], θtol, (pm, tx, rdom, r_rx, zrx, sig), ztol)
+          if θr !== nothing
+            v = _crossing_arrival(pm, tx, θr, rdom, r_rx, sig, ds; paths)
+            v === nothing || push!(results[i], v)
+          end
+        end
+      end
     end
     foreach(r -> append!(erays, r), results)
   end
   erays
+end
+
+# bisect from a supported launch angle θa toward an unsupported one θb (where
+# the signature is absent) and return a root of the per-signature depth error
+# if a sign change is found before the support edge; nothing otherwise. The
+# θ-support of a signature can be porous near tangency (a grazing ray's
+# hit/miss of the blocking feature flips with integration noise), which
+# defeats the standard bracketing solvers, so the search runs a NaN-aware
+# bisection on primal values; for dual-numbered inputs the root's derivatives
+# are then restored via the implicit function theorem (matching what
+# NonlinearSolve does for a clean bracket).
+function _edge_root(θa, θb, fa, θtol, params, ztol)
+  pf = ϕ -> ForwardDiff.value(_Δz_sig(ϕ, params))
+  lo, hi = ForwardDiff.value(θa), ForwardDiff.value(θb)
+  flo = ForwardDiff.value(fa)
+  found = false
+  local θ2, f2
+  while abs(hi - lo) > θtol
+    m = (lo + hi) / 2
+    fm = pf(m)
+    if isnan(fm)
+      hi = m
+    elseif sign(fm) * sign(flo) < 0
+      θ2, f2 = m, fm
+      found = true
+      break
+    else
+      lo = m
+    end
+  end
+  found || return nothing
+  θ1, f1 = lo, flo
+  # NaN-aware bisection on [θ1, θ2]; NaN midpoints are replaced by a nearby
+  # supported angle (probes at ±j/20 of the interval), so a porous support
+  # only slows the shrink instead of killing it
+  while abs(θ2 - θ1) > θtol
+    m = (θ1 + θ2) / 2
+    fm = pf(m)
+    if isnan(fm)
+      ok = false
+      for j ∈ 1:9, s ∈ (1.0, -1.0)
+        x = m + s * j / 20 * (θ2 - θ1)
+        fx = pf(x)
+        isnan(fx) && continue
+        m, fm = x, fx
+        ok = true
+        break
+      end
+      ok || break
+    end
+    if sign(fm) == sign(f1)
+      θ1, f1 = m, fm
+    else
+      θ2, f2 = m, fm
+    end
+  end
+  θr, fr = abs(f1) < abs(f2) ? (θ1, f1) : (θ2, f2)
+  abs(fr) < ztol || return nothing
+  T1 = typeof(θa)
+  T1 <: ForwardDiff.Dual || return θr
+  # implicit function theorem: dθ*/dp = -(∂f/∂p) / (∂f/∂θ) at the root
+  slope = (f2 - f1) / (θ2 - θ1)
+  fD = _Δz_sig(convert(T1, θr), params)
+  isnan(ForwardDiff.value(fD)) && return convert(T1, θr)
+  convert(T1, θr) - (fD - ForwardDiff.value(fD)) / slope
 end

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -433,18 +433,19 @@ end
   # not equivalent either: knot events fire only for SampledField, so the
   # generic fallback integrates blindly across the ∂c kinks and its geometry
   # does not converge with solver tolerance.
-  function exact_z(v::AbstractVector, zs, θ0, R)
+  function exact_z(v::AbstractVector, zs, θ0, R; z3=-21.0)   # z3: depth of the third SSP node
     T = promote_type(eltype(v), typeof(zs), typeof(θ0), typeof(R))
-    cz(z) = z ≥ -10 ? v[1] + (v[2] - v[1]) * z / -10 : v[2] + (v[3] - v[2]) * (z + 10) / -11
+    h2 = z3 + 10                         # (signed) thickness of the second layer
+    cz(z) = z ≥ -10 ? v[1] + (v[2] - v[1]) * z / -10 : v[2] + (v[3] - v[2]) * (z + 10) / h2
     zofc(c, layer) = layer == 1 ? -10 * (c - v[1]) / (v[2] - v[1]) :
-                                  -11 * (c - v[2]) / (v[3] - v[2]) - 10
+                                  h2 * (c - v[2]) / (v[3] - v[2]) - 10
     k = cos(θ0) / cz(T(zs))
     z = T(zs)
     u = T(sin(θ0))                       # sin of ray angle, positive up
     r = zero(T)
     for _ ∈ 1:100_000
       layer = z > -10 ? 1 : z < -10 ? 2 : (u < 0 ? 2 : 1)
-      g = layer == 1 ? (v[2] - v[1]) / -10 : (v[3] - v[2]) / -11
+      g = layer == 1 ? (v[2] - v[1]) / -10 : (v[3] - v[2]) / h2
       slope = -k * g                     # du/dr within the layer (circular arc)
       zb = u > 0 ? (layer == 1 ? zero(T) : T(-10)) :
                    (layer == 1 ? T(-10) : T(-20))
@@ -472,9 +473,9 @@ end
     end
     error("no convergence")
   end
-  function ℳ₃(v)
+  function ℳ₃(v; z3=-21.0)
     env = UnderwaterEnvironment(bathymetry = 20.0,
-      soundspeed = SampledField([v[1], v[2], v[3]]; z=[0.0, -10.0, -21.0]),
+      soundspeed = SampledField([v[1], v[2], v[3]]; z=[0.0, -10.0, z3]),
       seabed = SandySilt)
     pm = RaySolver(env)
     tx = AcousticSource((x=0.0, z=-5.0), 5000.0)
@@ -482,13 +483,34 @@ end
   end
   import AcousticRayTracers
   x = [1500.0, 1490.0, 1510.0]
-  # the SSP domain extends below the seafloor: with the last knot exactly at
-  # the bottom, Interpolations.jl errors on Dual-indexed evaluation at the
-  # domain edge (JuliaMath/Interpolations#645), and reflections there carry a
-  # small systematic geometry offset (issue #29)
+  # SSP domain extending below the seafloor
   @test ℳ₃(x) ≈ exact_z(x, -5.0, -deg2rad(30), 100.0) atol=1e-3
   g = gradient(ℳ₃, AutoForwardDiff(), x)
   ge = gradient(v -> exact_z(v, -5.0, -deg2rad(30), 100.0), AutoForwardDiff(), x)
+  @test g ≈ ge atol=1e-3
+  # last SSP knot exactly on the bottom (issue #29): reflections there used to
+  # pick up the Flat()-extrapolated ∂c = 0 and carry a systematic mm-scale
+  # geometry offset; the clamped in-domain evaluation must match the analytic
+  # trajectory, and (Interpolations.jl #645) must not trip on the domain edge
+  @test ℳ₃(x; z3=-20.0) ≈ exact_z(x, -5.0, -deg2rad(30), 100.0; z3=-20.0) atol=1e-3
+  g = gradient(v -> ℳ₃(v; z3=-20.0), AutoForwardDiff(), x)
+  ge = gradient(v -> exact_z(v, -5.0, -deg2rad(30), 100.0; z3=-20.0), AutoForwardDiff(), x)
+  @test g ≈ ge atol=1e-3
+  # knot whose gradient jump is zero in the primal but nonzero under
+  # perturbation of a sample value (issue #30): the below-seafloor node keeps
+  # the same slope as the last water-column segment, so the trajectory (and
+  # its exact gradient) match the z3=-20 edge-knot case, and the AD gradient
+  # must not pick up spurious knot-event sensitivities
+  function ℳ₄(v)
+    env = UnderwaterEnvironment(bathymetry = 20.0,
+      soundspeed = SampledField([v[1], v[2], v[3], v[3] + 2]; z=[0.0, -10.0, -20.0, -21.0]),
+      seabed = SandySilt)
+    pm = RaySolver(env)
+    tx = AcousticSource((x=0.0, z=-5.0), 5000.0)
+    AcousticRayTracers._trace(pm, tx, -deg2rad(30), 100.0)[1].path[end].z
+  end
+  @test ℳ₄(x) ≈ exact_z(x, -5.0, -deg2rad(30), 100.0; z3=-20.0) atol=1e-3
+  g = gradient(ℳ₄, AutoForwardDiff(), x)
   @test g ≈ ge atol=1e-3
 end
 

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -564,4 +564,16 @@ end
   @test length(arr) > 0
   x = acoustic_field(pm, tx, AcousticReceiverGrid2D(100.0:100.0:1000.0, -90.0:10.0:-10.0))
   @test all(isfinite, abs.(x))
+  # sibling case (issue #32): the SSP minimum sits exactly on the −50 knot, so
+  # rays from the on-knot source turn exactly at the knot; a degenerate event
+  # rootfind there used to abort the whole solve (dt → 0 / NaN state)
+  env2 = UnderwaterEnvironment(
+    bathymetry = 90.0,
+    soundspeed = SampledField([1500.0, 1490.0, 1495.0]; z=[0.0, -50.0, -100.0]),
+    seabed = RigidBoundary
+  )
+  pm2 = RaySolver(env2)
+  arr2 = arrivals(pm2, tx, AcousticReceiver(1000.0, -20.0); paths=false)
+  @test length(arr2) > 0
+  @test all(isfinite(a.t) && isfinite(abs(a.ϕ)) for a ∈ arr2)
 end

--- a/test/test_raysolver.jl
+++ b/test/test_raysolver.jl
@@ -119,6 +119,37 @@ end
   @test xloss[50,50] ≈ 71.3 atol=0.5
   @test xloss[100,100] ≈ 75.8 atol=0.5end
 
+@testitem "raysolver-eigenrays-blocked" begin
+  # eigenray search behind blocking bathymetry (issue #31): adjacent fan rays
+  # alternately hit or clear the seamount, so the raw depth error Δz(θ) is
+  # discontinuous; the signature-grouped search must still find the multipath
+  # families that make it past the seamount, stably across fan resolutions
+  # (near-tangent skimming paths remain resolution-dependent and are not
+  # asserted). A receiver deep in the geometric shadow sees only steep
+  # multiple-bounce paths; a shallow receiver sees several families.
+  using UnderwaterAcoustics
+  bathy = SampledField([3000, 3000, 500, 3000, 3000]; x=[0, 10e3, 20e3, 30e3, 50e3])
+  env = UnderwaterEnvironment(bathymetry=bathy, soundspeed=1500.0,
+    seabed=FluidBoundary(1.5*water_density(), 1550.0, dBperλ(0.5)))
+  tx = AcousticSource((x=0, z=-18), 230.0)
+  rx = AcousticReceiver(40e3, -1500.0)
+  for nb ∈ (537, 2000)
+    pm = RaySolver(env; min_angle=-80°, max_angle=80°, nbeams=nb)
+    arr = arrivals(pm, tx, rx)
+    @test length(arr) ≥ 2
+    sigs = [(a.ns, a.nb) for a ∈ arr]
+    @test (1, 3) ∈ sigs && (2, 3) ∈ sigs
+    @test all(abs(a.path[end].z - (-1500)) < 0.5 for a ∈ arr)
+    @test all(abs(a.path[end].x - 40e3) < 0.5 for a ∈ arr)
+    i = findfirst(==((1, 3)), sigs)
+    @test arr[i].t ≈ 27.612 atol=1e-3
+  end
+  # shallow receiver: multiple families through the 500 m gap
+  pm = RaySolver(env; min_angle=-80°, max_angle=80°, nbeams=2000)
+  arr = arrivals(pm, tx, AcousticReceiver(40e3, -200.0))
+  @test length(arr) ≥ 5
+end
+
 @testitem "raysolver-backscatter" begin
   using UnderwaterAcoustics
   # null test: with nothing to backscatter, arrivals match the default solver


### PR DESCRIPTION
Fixes the four open issues from the RaySolver-vs-BELLHOP benchmarking study: #29, #30, #31, and the crash in #32. One commit per fix; all 142 tests pass (up from 125), including new regression testitems for each issue.

## What's fixed

### #29 / #30 — geometry error floor and gradient contamination at SSP knots (commit 1)
Two root causes, neither the suspected ones:
- **`reltol` was never set** on the ODE solves, so the solver default (1e-3) dominated `abstol` for O(10+) states and imposed a mm-scale geometry error floor that no `abstol` could remove. `reltol` now tracks `solver_tol`. This also turned out to be the entire cause of #30 — the "gradient contamination" was the derivative of the discretization-error floor, not the knot-event machinery.
- When the water column does not extend beyond the SSP's sampled domain, `c`/`∂c`/`∂²c` are evaluated strictly inside the domain with linear continuation past the edge, so reflections off a boundary coinciding with the outermost knot no longer pick up the flat-extrapolated `∂c = 0`. Where the water column *does* extend beyond the domain, flat extrapolation is preserved (it is genuinely reachable there). Side benefit: Dual-indexed evaluation exactly at the interpolant's domain edge (JuliaMath/Interpolations.jl#645) is avoided.

Verification: traced endpoints match an exact circular-arc reference to ~1 µm at `solver_tol=1e-12` with the last knot exactly on the bottom, and the #30 repro's AD gradient now matches the analytic one. The ∂raysolver exact tracer is parameterized to cover both configurations.

### #31 — eigenrays behind blocking bathymetry (commits 2 + 3)
- **Rays were tunneling through bathymetry features** (commit 2): an integration step straddling a boundary vertex (e.g. a seamount peak) can have both endpoints in the water, so the bottom-hit event never fires. This was the dominant cause of the non-monotonic arrival counts — the "direct" arrivals deep in the seamount's shadow were rays passing *through* rock (a straight ray to the −1500 m receiver at 40 km passes 259 m below the seafloor at the peak). Fixed with no-op ray events at boundary sample points, forcing a step onto every vertex (the discipline BELLHOP gets from stepping onto boundary polygon vertices).
- **Signature-grouped forward search** (commit 3): `arrivals` now reuses the backscatter path's `_fan_search` — crossings grouped by bounce history, root-finding within each family where Δz(θ) is continuous — plus a NaN-aware support-edge bisection that recovers roots hiding between the last supported fan sample and the tangency angle, with dual numbers restored via the implicit function theorem so AD through the search stays exact.

Verification: behind the benchmark seamount, the shallow receiver now gets 6 identical arrivals at 537/2000/8000 beams (previously 1/2/0 with different sets); the deep-shadow receiver retains its two robust steep families at all resolutions.

### #32 — dt→0 abort at rays turning on an SSP knot (commit 4)
The crash path (tangent event rootfind → NaN state → SSP interpolant throws → whole solve aborts) is fixed by guarding `_∂u` against NaN states, so the solver aborts only the affected segment; a truncated ray yields a NaN depth error that the eigenray search already rejects. The issue's repro (channel axis on the −50 knot, source on the knot) now returns 59 finite arrivals.

## Limitations — what does *not* work

- **Near-tangent arrivals remain resolution-dependent.** Arrival families whose launch-angle support is a hair-thin sliver at a tangency (deep in a geometric shadow, grazing along a slope) appear and disappear with fan resolution. Their hit/miss boundary is chaotic at any `nbeams`, and their physics is diffraction-dominated — beyond ray theory. BELLHOP reports more arrivals in these regions because its beam-influence binning effectively spreads finite-width beams into the shadow; an exact eigenray search cannot (and arguably should not) reproduce that.
- **Support-edge refinement is forward-only.** In backscatter mode the marginal grazing echoes it recovers make the echo TL discontinuous w.r.t. scatterer geometry (±0.4 dB over mm-scale scatterer displacement), destroying differentiability of the primal. Backscatter keeps the previous behavior. This is an internal policy, not an option, by design.
- **#32 is only fixed for the crash.** On SSP-extremum-on-knot configurations, ForwardDiff gradients through the eigenray search are ~180× slower than the primal (the event-time derivative is singular at tangency and the dual-typed root solves converge poorly), and their accuracy has no independent reference — the coherent field there is too oscillatory for finite differences to validate against. Ordinary AD use (the ∂raysolver scenarios) is unaffected in speed and verified against the exact tracer. A contained follow-up exists if this bites: solve the eigenray roots on primal values and re-inject duals via the implicit function theorem (the machinery `_edge_root` already uses), which would also make the gradients well-defined at turning-point singularities.
- The `raysolver-eigenrays-blocked` testitem deliberately asserts only the resolution-stable families.
